### PR TITLE
v1.2.0: Performance Overhaul and BC Artifacts Sidebar Launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to **BC Docker Manager** are documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versions follow [Semantic Versioning](https://semver.org/).
+
+---
+
+## [1.2.0] - 2026-04-30
+
+### Added
+- **BC Artifacts sidebar section**: a dedicated "BC Artifacts" panel in the BC Docker Manager activity bar with a one-click *Open BC Artifacts Explorer* button. No more digging through the command palette.
+- Globe and Refresh icon buttons in the BC Artifacts section title bar for quick access and panel reload.
+
+### Improved
+- **Halved Docker CLI calls per tree refresh**: `getBcContainers()` now reuses the already-fetched container list instead of issuing a second `docker ps` + `docker inspect` pair. Two round-trips became one.
+- **Volume SWR cache (30 s TTL)**: `getVolumes()` now returns cached data on rapid refreshes instead of querying Docker on every panel repaint. Cache is invalidated immediately after create/remove operations.
+- **NAV exec split**: `execInContainer()` (utility PowerShell commands like `Test-Path`, `Remove-Item`, `Invoke-Sqlcmd`) no longer prepends the `NavAdminTool.ps1` wildcard import. A new `execNavInContainer()` carries that cost only for commands that actually need NAV cmdlets.
+- **CDN URL constant**: `bcArtifactsService` now uses the `CDN_BASE` constant in `_parseVersions()`. Previously the URL was duplicated inline, which would silently break artifact URLs if the CDN endpoint ever changed.
+- **O(1) pending-write cleanup**: `_pendingWrites` upgraded from `Array` (O(n) filter on completion) to `Set` (O(1) delete).
+- **Artifacts Explorer auto-open**: the panel now opens automatically only on first install, not on every VS Code launch.
+
+### Fixed
+- `DockerService` EventEmitter was not disposed on extension deactivation. It is now registered in `context.subscriptions` via `implements vscode.Disposable`.
+
+---
+
+## [1.1.0] - 2026-03-31
+
+### Fixed
+- Add BC User and Add Test Users commands failed with *New-NAVServerUser is not recognized*. NAV management module (`NavAdminTool.ps1`) is now imported before executing NAV cmdlets inside Docker containers.
+
+---
+
+## [1.0.13] - 2026-03-20
+
+### Fixed
+- Extension crashed on startup (*command not found: bcDockerManager.refreshEnvironment*) because `node_modules` was excluded from the VSIX. Removed `node_modules/**` from `.vscodeignore` so production dependencies are packaged correctly.
+- Removed unused `sharp` dependency.
+
+---
+
+## [1.0.0] - 2024-02-01
+
+### Added
+- Initial public release.
+- BC Artifacts Explorer webview: browse, filter, and pull BC container images without BcContainerHelper.
+- Container management tree view: start, stop, restart, and remove containers.
+- Image management: pull BC images, pre-pull with progress, remove images.
+- Volume management: create, remove, and inspect Docker volumes.
+- Environment health panel: Hyper-V, Windows Containers, and Docker Engine status with one-click setup.
+- AL developer tools: publish app, upload license, add users, backup/restore database, compile AL app, edit NST settings, view event log.
+- `launch.json` generation, preview, and clipboard copy for AL projects.
+- Container profiles: save and load container configurations.
+- Bulk container operations: start all, stop all, remove all stopped.
+- Azure Application Insights telemetry (opt-out via VS Code privacy settings).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bc-docker-manager",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bc-docker-manager",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/extension-telemetry": "^1.5.1"

--- a/package.json
+++ b/package.json
@@ -68,6 +68,11 @@
           "id": "bcDockerManager-volumes",
           "name": "Volumes",
           "icon": "$(database)"
+        },
+        {
+          "id": "bcDockerManager-artifacts",
+          "name": "BC Artifacts",
+          "icon": "$(globe)"
         }
       ]
     },
@@ -91,6 +96,10 @@
         "view": "bcDockerManager-volumes",
         "contents": "No volumes found.\n[Create Volume](command:bcDockerManager.createVolume)",
         "when": "bcDockerManager.dockerReady"
+      },
+      {
+        "view": "bcDockerManager-artifacts",
+        "contents": "Browse and download Business Central artifacts from Microsoft's CDN.\n\n[Open BC Artifacts Explorer](command:bcDockerManager.openExplorer)"
       }
     ],
     "configuration": {
@@ -476,6 +485,16 @@
         {
           "command": "bcDockerManager.createVolume",
           "when": "view == bcDockerManager-volumes",
+          "group": "navigation@2"
+        },
+        {
+          "command": "bcDockerManager.openExplorer",
+          "when": "view == bcDockerManager-artifacts",
+          "group": "navigation@1"
+        },
+        {
+          "command": "bcDockerManager.refreshRegistry",
+          "when": "view == bcDockerManager-artifacts",
           "group": "navigation@2"
         },
         {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bc-docker-manager",
   "displayName": "BC Docker Manager",
   "description": "Manage Business Central Docker containers from VS Code - browse artifacts, create containers, develop AL apps, and configure your environment without BcContainerHelper or Docker Desktop.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "icon": "resources/icon.png",
   "publisher": "jeffreybulanadi",
   "author": {

--- a/src/docker/bcContainerService.ts
+++ b/src/docker/bcContainerService.ts
@@ -1,8 +1,10 @@
 import { exec } from "child_process";
 import * as fs from "fs";
+import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
 import { DockerService } from "./dockerService";
+import { SWRCache } from "../services/swrCache";
 
 // ────────────────────────── Constants ───────────────────────────
 
@@ -28,7 +30,11 @@ const NAV_MODULE_IMPORT =
  * This keeps dockerService.ts focused on generic Docker operations.
  */
 export class BcContainerService {
-  constructor(private docker: DockerService) {}
+  private readonly _volumeCache: SWRCache<DockerVolume[]>;
+
+  constructor(private docker: DockerService) {
+    this._volumeCache = new SWRCache<DockerVolume[]>(30_000);
+  }
 
   // ── shell helper ─────────────────────────────────────────────
 
@@ -44,8 +50,21 @@ export class BcContainerService {
     });
   }
 
-  /** Run a PowerShell command inside a container. */
+  /** Run a PowerShell utility command inside a container (no NAV module). */
   private async execInContainer(
+    containerName: string,
+    psCommand: string,
+    timeoutMs = EXEC_TIMEOUT_MS,
+  ): Promise<string> {
+    const escaped = psCommand.replace(/"/g, '\\"');
+    return this.exec(
+      `docker exec ${containerName} powershell -NoProfile -Command "${escaped}"`,
+      timeoutMs,
+    );
+  }
+
+  /** Run a NAV/BC PowerShell cmdlet inside a container (imports NavAdminTool). */
+  private async execNavInContainer(
     containerName: string,
     psCommand: string,
     timeoutMs = EXEC_TIMEOUT_MS,
@@ -128,11 +147,11 @@ export class BcContainerService {
           `-Path '${containerPath}'`,
           `-SkipVerification`,
         ].join(" ");
-        await this.execInContainer(containerName, publishCmd, 300_000);
+        await this.execNavInContainer(containerName, publishCmd, 300_000);
 
         // Step 4: Sync and install
         progress.report({ message: "Syncing & installing…" });
-        const appInfo = await this.execInContainer(
+        const appInfo = await this.execNavInContainer(
           containerName,
           `Get-NAVAppInfo -Path '${containerPath}' | ConvertTo-Json -Depth 1`,
         );
@@ -141,14 +160,14 @@ export class BcContainerService {
           const appName = info.Name || info.name;
           const appVersion = info.Version || info.version;
           if (appName && appVersion) {
-            await this.execInContainer(
+            await this.execNavInContainer(
               containerName,
               `Sync-NAVApp -ServerInstance '${serverInstance}' -Name '${appName}' -Version '${appVersion}' -Mode ForceSync`,
               120_000,
             );
             // Try install, but it may already be installed (upgrade case)
             try {
-              await this.execInContainer(
+              await this.execNavInContainer(
                 containerName,
                 `Install-NAVApp -ServerInstance '${serverInstance}' -Name '${appName}' -Version '${appVersion}' -Force`,
                 120_000,
@@ -156,7 +175,7 @@ export class BcContainerService {
             } catch {
               // If install fails, try Start-NAVAppDataUpgrade for upgrades
               try {
-                await this.execInContainer(
+                await this.execNavInContainer(
                   containerName,
                   `Start-NAVAppDataUpgrade -ServerInstance '${serverInstance}' -Name '${appName}' -Version '${appVersion}' -Force`,
                   120_000,
@@ -208,14 +227,14 @@ export class BcContainerService {
         const serverInstance = await this.getServerInstance(containerName);
 
         progress.report({ message: "Importing license…" });
-        await this.execInContainer(
+        await this.execNavInContainer(
           containerName,
           `Import-NAVServerLicense -ServerInstance '${serverInstance}' -LicenseFile '${containerPath}' -Database NavDatabase -Force`,
           60_000,
         );
 
         progress.report({ message: "Restarting service tier…" });
-        await this.execInContainer(
+        await this.execNavInContainer(
           containerName,
           `Restart-NAVServerInstance -ServerInstance '${serverInstance}' -Force`,
           120_000,
@@ -261,7 +280,7 @@ export class BcContainerService {
       { location: vscode.ProgressLocation.Notification, title: `Adding user "${username}"…` },
       async () => {
         const serverInstance = await this.getServerInstance(containerName);
-        await this.execInContainer(
+        await this.execNavInContainer(
           containerName,
           [
             `$pw = ConvertTo-SecureString '${password.replace(/'/g, "''")}' -AsPlainText -Force;`,
@@ -297,7 +316,7 @@ export class BcContainerService {
         for (const user of testUsers) {
           progress.report({ message: `Creating ${user.name}…` });
           try {
-            await this.execInContainer(
+            await this.execNavInContainer(
               containerName,
               [
                 `$pw = ConvertTo-SecureString 'P@ssw0rd' -AsPlainText -Force;`,
@@ -322,7 +341,7 @@ export class BcContainerService {
     const saveUri = await vscode.window.showSaveDialog({
       filters: { "Database Backup": ["bak"] },
       defaultUri: vscode.Uri.file(
-        path.join(require("os").homedir(), `${containerName}_backup.bak`),
+        path.join(os.homedir(), `${containerName}_backup.bak`),
       ),
       title: "Save database backup as…",
     });
@@ -395,7 +414,7 @@ export class BcContainerService {
         await this.copyToContainer(containerName, hostPath, containerBakPath);
 
         progress.report({ message: "Stopping service tier…" });
-        await this.execInContainer(
+        await this.execNavInContainer(
           containerName,
           `Set-NAVServerInstance -ServerInstance '${serverInstance}' -Stop`,
           60_000,
@@ -409,7 +428,7 @@ export class BcContainerService {
         );
 
         progress.report({ message: "Starting service tier…" });
-        await this.execInContainer(
+        await this.execNavInContainer(
           containerName,
           `Set-NAVServerInstance -ServerInstance '${serverInstance}' -Start`,
           120_000,
@@ -487,7 +506,7 @@ export class BcContainerService {
         for (const app of apps) {
           progress.report({ message: `Publishing ${app.Name} (${++published}/${apps.length})…` });
           try {
-            await this.execInContainer(
+            await this.execNavInContainer(
               containerName,
               `Publish-NAVApp -ServerInstance '${serverInstance}' -Path '${app.FullName}' -SkipVerification -Install`,
               120_000,
@@ -557,7 +576,7 @@ export class BcContainerService {
     const raw = await vscode.window.withProgress(
       { location: vscode.ProgressLocation.Notification, title: "Reading NST settings…" },
       async () => {
-        return await this.execInContainer(
+        return await this.execNavInContainer(
           containerName,
           `Get-NAVServerConfiguration -ServerInstance '${serverInstance}' | Select-Object KeyName, Value | ConvertTo-Json -Depth 1`,
           30_000,
@@ -597,7 +616,7 @@ export class BcContainerService {
     await vscode.window.withProgress(
       { location: vscode.ProgressLocation.Notification, title: `Updating ${selected.label}…` },
       async () => {
-        await this.execInContainer(
+        await this.execNavInContainer(
           containerName,
           `Set-NAVServerConfiguration -ServerInstance '${serverInstance}' -KeyName '${selected.label}' -KeyValue '${newValue.replace(/'/g, "''")}'`,
         );
@@ -608,7 +627,7 @@ export class BcContainerService {
           "Later",
         );
         if (restart === "Restart Now") {
-          await this.execInContainer(
+          await this.execNavInContainer(
             containerName,
             `Restart-NAVServerInstance -ServerInstance '${serverInstance}' -Force`,
             120_000,
@@ -788,8 +807,6 @@ export class BcContainerService {
       { location: vscode.ProgressLocation.Notification, title: "Compiling AL app…" },
       async (progress) => {
         const serverInstance = await this.getServerInstance(containerName);
-
-        // Find the AL compiler in the container
         progress.report({ message: "Locating AL compiler…" });
         const alcPath = await this.execInContainer(
           containerName,
@@ -856,7 +873,7 @@ export class BcContainerService {
     const saveUri = await vscode.window.showSaveDialog({
       filters: { "Docker Image": ["tar"] },
       defaultUri: vscode.Uri.file(
-        path.join(require("os").homedir(), `${containerName}.tar`),
+        path.join(os.homedir(), `${containerName}.tar`),
       ),
       title: "Export container as…",
     });
@@ -904,6 +921,10 @@ export class BcContainerService {
   // ── v1.4: Volume Management ──────────────────────────────────
 
   async getVolumes(): Promise<DockerVolume[]> {
+    return this._volumeCache.get("all", () => this._fetchVolumes());
+  }
+
+  private async _fetchVolumes(): Promise<DockerVolume[]> {
     const raw = await this.exec('docker volume ls --format "{{json .}}"');
     return raw
       .split("\n")
@@ -926,11 +947,13 @@ export class BcContainerService {
     });
     if (!name) { return; }
     await this.exec(`docker volume create ${name}`);
+    this._volumeCache.invalidate("all");
     vscode.window.showInformationMessage(`Volume "${name}" created.`);
   }
 
   async removeVolume(name: string): Promise<void> {
     await this.exec(`docker volume rm ${name}`);
+    this._volumeCache.invalidate("all");
   }
 
   async inspectVolume(name: string): Promise<void> {
@@ -959,7 +982,7 @@ export class BcContainerService {
     }
 
     try {
-      const raw = await this.execInContainer(
+      const raw = await this.execNavInContainer(
         containerName,
         [
           `$si = (Get-NAVServerInstance | Select-Object -First 1).ServerInstance -replace '.*\\\\$', '';`,

--- a/src/docker/dockerService.ts
+++ b/src/docker/dockerService.ts
@@ -67,7 +67,7 @@ const BC_IMAGE = "mcr.microsoft.com/businesscentral:ltsc2022";
  * Pure Docker CLI wrapper. No PowerShell modules, no external
  * frameworks — just `docker` commands parsed from JSON output.
  */
-export class DockerService {
+export class DockerService implements vscode.Disposable {
 
   /** Fires when background SWR revalidation produces updated data. */
   private readonly _onDidUpdate = new vscode.EventEmitter<void>();
@@ -80,6 +80,10 @@ export class DockerService {
     const notify = () => this._onDidUpdate.fire();
     this._containerCache = new SWRCache<DockerContainer[]>(10_000, notify);
     this._imageCache = new SWRCache<DockerImage[]>(10_000, notify);
+  }
+
+  dispose(): void {
+    this._onDidUpdate.dispose();
   }
 
   /** True if the last ensureNetworking() call actually ran a fix (UAC elevation). */
@@ -153,20 +157,13 @@ export class DockerService {
   }
 
   private async _fetchBcContainers(): Promise<DockerContainer[]> {
-    // Single docker ps call with Labels included for client-side filtering
-    const raw = await this.exec(
-      'docker ps -a --no-trunc --format "{{json .}}"'
-    );
-    const all = this.parseLinesWithLabelsHint(raw);
+    // Reuse the already-enriched "all" containers list — no second docker ps or docker inspect.
+    const all = await this.getContainers();
 
-    // Prefer label-filtered containers; fall back to image name heuristic
-    let containers = all.filter((c) => c._hasNavLabel);
+    // Prefer label-based detection (official BC images set a "nav" label).
+    let containers = all.filter((c) => "nav" in c.labels || c.labels["maintainer"] === "Dynamics SMB");
     if (containers.length === 0) {
       containers = all.filter((c) => this.looksLikeBcImage(c.image));
-    }
-
-    if (containers.length > 0) {
-      await this.enrichWithLabels(containers);
     }
     return containers;
   }
@@ -419,29 +416,6 @@ export class DockerService {
           id: obj["ID"] ?? "",
           size: obj["Size"] ?? "",
           createdAt: obj["CreatedAt"] ?? "",
-        };
-      });
-  }
-
-  /** Like parseLines but also extracts the raw Labels string for filtering. */
-  private parseLinesWithLabelsHint(raw: string): (DockerContainer & { _hasNavLabel: boolean })[] {
-    return raw
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map((line) => {
-        const obj = JSON.parse(line) as Record<string, string>;
-        const labelsRaw = obj["Labels"] ?? "";
-        return {
-          id: obj["ID"] ?? "",
-          names: obj["Names"] ?? "",
-          image: obj["Image"] ?? "",
-          status: obj["Status"] ?? "",
-          state: obj["State"] ?? "",
-          ports: obj["Ports"] ?? "",
-          createdAt: obj["CreatedAt"] ?? "",
-          labels: {},
-          _hasNavLabel: labelsRaw.includes("nav="),
         };
       });
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { VolumeProvider } from "./tree/volumeProvider";
 import { RegistryPanel } from "./webview/registryPanel";
 import { ContainerTreeItem, ImageTreeItem } from "./tree/models";
 import { VolumeTreeItem } from "./tree/volumeProvider";
+import { ArtifactsLauncherProvider } from "./tree/artifactsLauncherProvider";
 import { initTelemetry, disposeTelemetry, sendEvent, sendError } from "./services/telemetry";
 
 /**
@@ -36,6 +37,7 @@ export async function activate(
   const imageProvider = new ImageProvider(docker);
   const healthProvider = new DockerHealthProvider();
   const volumeProvider = new VolumeProvider(bcService);
+  const artifactsLauncherProvider = new ArtifactsLauncherProvider();
 
   // Preload countries in background so the panel opens instantly.
   // This warms up the TLS connection + populates memory & disk cache.
@@ -58,6 +60,9 @@ export async function activate(
     }),
     vscode.window.createTreeView("bcDockerManager-volumes", {
       treeDataProvider: volumeProvider,
+    }),
+    vscode.window.createTreeView("bcDockerManager-artifacts", {
+      treeDataProvider: artifactsLauncherProvider,
     }),
     healthProvider,
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,9 @@ export async function activate(
   artifacts.getCountries("sandbox").catch(() => {});
   artifacts.getCountries("onprem").catch(() => {});
 
+  // Register DockerService for disposal so its EventEmitter is cleaned up.
+  context.subscriptions.push(docker);
+
   // ── Tree views ─────────────────────────────────────────────────
   context.subscriptions.push(
     vscode.window.createTreeView("bcDockerManager-environment", {
@@ -97,8 +100,11 @@ export async function activate(
     })
   );
 
-  // Auto-open BC Artifacts Explorer on activation
-  RegistryPanel.show(artifacts, docker, context.extensionUri);
+  // Auto-open BC Artifacts Explorer on first install only.
+  if (!context.globalState.get<boolean>("bcDockerManager.hasAutoOpened")) {
+    context.globalState.update("bcDockerManager.hasAutoOpened", true);
+    RegistryPanel.show(artifacts, docker, context.extensionUri);
+  }
 
   // Diagnostic: test CDN connectivity from inside the extension host
   context.subscriptions.push(

--- a/src/registry/bcArtifactsService.ts
+++ b/src/registry/bcArtifactsService.ts
@@ -68,7 +68,7 @@ export class BcArtifactsService {
   private _diskCacheDir: string | undefined;
 
   /** Pending disk-write promises (for test flushing). */
-  private _pendingWrites: Promise<void>[] = [];
+  private _pendingWrites = new Set<Promise<void>>();
 
   /**
    * Call once after construction to enable disk caching.
@@ -153,10 +153,8 @@ export class BcArtifactsService {
     const fp = this._diskCachePath(key);
     if (!fp) { return; }
     const p = fsp.writeFile(fp, JSON.stringify(data)).catch(() => { /* best-effort */ });
-    this._pendingWrites.push(p);
-    p.then(() => {
-      this._pendingWrites = this._pendingWrites.filter((w) => w !== p);
-    });
+    this._pendingWrites.add(p);
+    p.finally(() => this._pendingWrites.delete(p));
   }
 
   /** Wait for all pending disk writes to complete. Useful for testing. */
@@ -272,7 +270,7 @@ export class BcArtifactsService {
         minor: parseInt(parts[1], 10) || 0,
         type,
         country,
-        artifactUrl: `https://bcartifacts-exdbf9fwegejdqak.b02.azurefd.net/${type}/${entry.Version}/${country}`,
+        artifactUrl: `${CDN_BASE}/${type}/${entry.Version}/${country}`,
       };
     });
 

--- a/src/tree/artifactsLauncherProvider.ts
+++ b/src/tree/artifactsLauncherProvider.ts
@@ -1,0 +1,16 @@
+import * as vscode from "vscode";
+
+/**
+ * Empty tree data provider for the BC Artifacts sidebar view.
+ * Returns no items so VS Code renders the viewsWelcome content,
+ * which contains the "Open BC Artifacts Explorer" button.
+ */
+export class ArtifactsLauncherProvider implements vscode.TreeDataProvider<never> {
+    getTreeItem(): vscode.TreeItem {
+        return new vscode.TreeItem("");
+    }
+
+    getChildren(): never[] {
+        return [];
+    }
+}


### PR DESCRIPTION
## Summary

This PR delivers two things: a performance audit and a new BC Artifacts sidebar entry point.

---

## What Changed

### Performance

| Area | Before | After |
|------|--------|-------|
| Docker CLI calls per tree refresh | 4 (docker ps x2 + docker inspect x2) | 2 (docker ps x1 + docker inspect x1) |
| Volume list query | Every panel repaint | SWR cache, 30s TTL, invalidated on mutations |
| NavAdminTool.ps1 import | Every docker exec call | Only calls that use NAV cmdlets |
| BC Artifacts Explorer auto-open | Every VS Code launch | First install only |
| DockerService EventEmitter | Never disposed | Disposed via context.subscriptions |
| _pendingWrites cleanup | O(n) Array filter | O(1) Set delete |
| CDN base URL | Hardcoded duplicate in _parseVersions() | Uses CDN_BASE constant |

### New Feature

- BC Artifacts sidebar section: a dedicated panel in the activity bar with a one-click Open BC Artifacts Explorer button. No command palette required.
- Globe (open) and Refresh icon buttons in the section title bar.
- Backed by ArtifactsLauncherProvider (empty tree provider) so VS Code renders the welcome content instead of an infinite loading spinner.

---

## Files Changed

| File | Description |
|------|-------------|
| src/docker/dockerService.ts | Cache reuse, dispose, remove duplicate parser |
| src/docker/bcContainerService.ts | Volume SWR cache, exec split, os import |
| src/registry/bcArtifactsService.ts | CDN constant, Set for pending writes |
| src/extension.ts | First-install auto-open, subscribe docker for dispose, register artifacts view |
| src/tree/artifactsLauncherProvider.ts | New - minimal empty tree provider |
| package.json | New view, viewsWelcome, menu buttons, version 1.2.0 |
| CHANGELOG.md | New - full release history |

---

## How to Test

1. Press F5 to open Extension Development Host
2. Click the BC Docker Manager icon in the activity bar
3. Scroll to the BC ARTIFACTS section - button should be visible immediately
4. Click Open BC Artifacts Explorer - panel opens, countries pre-loaded
5. Open the Containers view - tree refresh should feel snappier (only 1 docker ps fired per cycle)
6. Close and reopen VS Code - Artifacts Explorer should not auto-open again