### PR TITLE
Settings ignored when creating containers and loading default country

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.2.1] - 2026-04-30
+
+### Fixed
+- Extension settings were ignored when creating containers. `defaultIsolation`, `defaultMemory`, and `defaultAuth` were hardcoded in the container creation flow, so containers always used `hyperv` isolation and `8G` memory regardless of what was configured. Reported in [#3](https://github.com/jeffreybulanadi/bc-docker-manager/issues/3).
+- `defaultCountry` setting was ignored when opening the Artifacts Explorer. The panel always loaded `us` on open instead of the configured country. Also reported in [#3](https://github.com/jeffreybulanadi/bc-docker-manager/issues/3).
+
+---
+
 ## [1.2.0] - 2026-04-30
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bc-docker-manager",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bc-docker-manager",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@vscode/extension-telemetry": "^1.5.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bc-docker-manager",
   "displayName": "BC Docker Manager",
   "description": "Manage Business Central Docker containers from VS Code - browse artifacts, create containers, develop AL apps, and configure your environment without BcContainerHelper or Docker Desktop.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "icon": "resources/icon.png",
   "publisher": "jeffreybulanadi",
   "author": {

--- a/src/webview/registryPanel.ts
+++ b/src/webview/registryPanel.ts
@@ -160,13 +160,13 @@ export class RegistryPanel {
     // 2. Container name
     const defaultName = `bc${version.split(".")[0]}${country}`;
     const name = await vscode.window.showInputBox({
-      title: "Create BC Container (1/3) — Name",
+      title: "Create BC Container (1/3): Name",
       prompt: "Container name (lowercase, no spaces)",
       value: defaultName,
       validateInput: (v) => {
         if (!v) { return "Name is required"; }
         if (!/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/.test(v)) {
-          return "Invalid container name — use letters, numbers, dash, dot, underscore";
+          return "Invalid container name. Use letters, numbers, dash, dot, or underscore";
         }
         return undefined;
       },
@@ -175,14 +175,14 @@ export class RegistryPanel {
 
     // 3. Credentials
     const username = await vscode.window.showInputBox({
-      title: "Create BC Container (2/3) — Username",
+      title: "Create BC Container (2/3): Username",
       prompt: "Admin username for the BC instance",
       value: "admin",
     });
     if (!username) { return; }
 
     const password = await vscode.window.showInputBox({
-      title: "Create BC Container (3/3) — Password",
+      title: "Create BC Container (3/3): Password",
       prompt: "Admin password",
       password: true,
       validateInput: (v) => {
@@ -202,6 +202,11 @@ export class RegistryPanel {
     if (eula !== "Accept") { return; }
 
     // 5. Create container using native docker run
+    const config = vscode.workspace.getConfiguration("bcDockerManager");
+    const memoryLimit = config.get<string>("defaultMemory", "8G");
+    const isolation = config.get<"hyperv" | "process">("defaultIsolation", "hyperv");
+    const auth = config.get<string>("defaultAuth", "UserPassword");
+
     const output = vscode.window.createOutputChannel("BC Container Creation");
     output.show(true);
 
@@ -219,8 +224,9 @@ export class RegistryPanel {
             artifactUrl,
             username,
             password,
-            memoryLimit: "8G",
-            auth: "UserPassword",
+            memoryLimit,
+            isolation,
+            auth,
             updateHosts: true,
           },
           output,
@@ -236,7 +242,7 @@ export class RegistryPanel {
           cancellable: false,
         },
         async (progress) => {
-          progress.report({ message: "Downloading artifacts and installing BC (5-15 min)…" });
+          progress.report({ message: "Downloading artifacts and installing BC (5-15 min)..." });
           return this._docker.waitForContainerReady(name, output);
         },
       );
@@ -288,9 +294,9 @@ export class RegistryPanel {
   }
 
   private async _initPanel(): Promise<void> {
-    // Auto-load sandbox with a sensible default country (e.g. "us")
-    // so the user sees data immediately instead of a blank prompt.
-    await this._handleLoadCountry("sandbox");
+    const config = vscode.workspace.getConfiguration("bcDockerManager");
+    const defaultCountry = config.get<string>("defaultCountry", "us");
+    await this._handleLoadCountry("sandbox", defaultCountry);
   }
 
   private async _handleLoadCountry(


### PR DESCRIPTION
Closes #3

## Root cause

Two separate hardcoding issues in registryPanel.ts:

1. _handleCreateContainer() passed memoryLimit: '8G', auth: 'UserPassword', and no isolation to createBcContainer(). The bcDockerManager.defaultIsolation, bcDockerManager.defaultMemory, and bcDockerManager.defaultAuth settings were never read, so containers always used hyperv isolation regardless of what the user configured.

2. _initPanel() called _handleLoadCountry('sandbox') without a country argument. The fallback logic in _handleLoadCountry() then hardcoded 'us' (or the first available country), completely ignoring bcDockerManager.defaultCountry.

## What changed

- _handleCreateContainer() now reads defaultMemory, defaultIsolation, and defaultAuth from workspace configuration before calling createBcContainer()
- _initPanel() now reads defaultCountry from workspace configuration and passes it to _handleLoadCountry()

## How to test

1. Go to Settings > Extensions > BC Docker Manager
2. Set Default Isolation to process, Default Country to w1
3. Open the Artifacts Explorer and verify it loads the w1 country on open
4. Create a container, then run: docker inspect <name> --format '{{.HostConfig.Isolation}}'
5. Result should be process, not hyperv

## Proof of Work

https://github.com/user-attachments/assets/00890d1b-f447-4401-8676-f57802e04d7e
