### PR TITLE
Streaming file transfer for Hyper-V containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,22 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.3.2] - 2026-05-01
+
+### Changed
+
+- All file transfers between the host and Hyper-V containers now go through a single persistent `docker exec` spawn instead of spawning a new PowerShell process per chunk. License upload, app publish, database backup, database restore, and AL compilation previously opened one process every 5-50 KB of data. On a 500 MB backup that was roughly 10,000 process starts at ~400 ms each. The transfer now streams through one long-lived process, keeping a 48 KB sliding window in memory regardless of file size, and completes in seconds rather than hours.
+
+- SQL Server Express edition is now detected automatically before each backup attempt. When Express is detected, the `COMPRESSION` option is omitted from the `BACKUP DATABASE` statement. Previously the command failed with `BACKUP DATABASE WITH COMPRESSION is not supported on Express`, requiring the user to switch editions manually.
+
+- PowerShell ANSI color escape sequences are stripped from error messages before they are shown in VS Code notifications. The raw terminal codes were leaking into toasts and output channel messages as garbled characters.
+
+---
+
 ## [1.3.1] - 2025-05-01
 
-### Fixed
+### Changed
+
 - Changing country while a specific BC major version (e.g. BC25) was selected showed 0 results. The filter state was reset on country change but the major dropdown kept its previous selection, causing the client-side major filter to exclude all rows returned by the unfiltered `getLatestVersions` fetch (which returns the most recent N versions, typically a different major). The extension now passes the selected major with the country-change request and fetches `getMajorVersions` and `getVersionsByMajor` in parallel, returning the major-specific results directly. If the selected major has no releases in the new country, the extension sends a `majorNotFound` signal so the frontend resets the filter to show all versions.
 - Changing the artifact tab (Sandbox vs OnPrem) while a major was selected could produce 0 results for the same reason. The tab change handler now resets the major dropdown to "All" before loading, since a tab switch is an explicit context change rather than a cross-country comparison.
 - Country dropdown was rebuilt from scratch on every `countries` message without restoring the previously selected value. The selection is now preserved using the same pattern as the major dropdown.

--- a/README.md
+++ b/README.md
@@ -193,10 +193,12 @@ BC containers use self-signed certificates and custom hostnames. This extension 
 
 ## Database Operations
 
+All file transfers run through a single streaming process, so backup and restore are fast even on large databases and work without issue on Hyper-V containers.
+
 | Command | What it does |
 |---------|-------------|
-| **Backup Database** | Creates a compressed `.bak` file via SQL Server |
-| **Restore Database** | Restores from backup (stops > restores > restarts the service tier) |
+| **Backup Database** | Creates a `.bak` file via SQL Server. Express edition is detected automatically and compression is skipped when needed. |
+| **Restore Database** | Restores from a `.bak` file (stops the service tier, restores, restarts). |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bc-docker-manager",
   "displayName": "BC Docker Manager",
   "description": "Manage Business Central Docker containers from VS Code - browse artifacts, create containers, develop AL apps, and configure your environment without BcContainerHelper or Docker Desktop.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "icon": "resources/icon.png",
   "publisher": "jeffreybulanadi",
   "author": {

--- a/src/docker/bcContainerService.test.ts
+++ b/src/docker/bcContainerService.test.ts
@@ -2,7 +2,8 @@
  * Unit tests for BcContainerService.
  *
  * Tests focus on:
- *  - Shell helpers (exec, execInContainer, copy) via casting to `any`
+ *  - Shell helpers (exec, execInContainer) via casting to `any`
+ *  - File transfer helpers (writeFileToContainer, readFileFromContainer) via Base64 chunking
  *  - Cached metadata (getContainerInfo with TTL)
  *  - Copy Container IP
  *  - Volume parsing (getVolumes, removeVolume)
@@ -129,25 +130,83 @@ describe("execInContainer", () => {
   });
 });
 
-// ─── copyToContainer / copyFromContainer (private) ───────────────
+// ─── writeFileToContainer (private) ──────────────────────────────
 
-describe("copyToContainer", () => {
-  it("runs docker cp from host to container", async () => {
+describe("writeFileToContainer", () => {
+  it("writes an empty file via WriteAllBytes with empty array", async () => {
+    mockFs.readFileSync.mockReturnValueOnce(Buffer.alloc(0));
+    fakeExecOk(""); // execInContainer for empty file
+    await (svc as any).writeFileToContainer("mybc", "C:\\host\\empty.txt", "C:\\run\\my\\empty.txt");
+    const cmd: string = mockExec.mock.calls[0][0];
+    expect(cmd).toContain("WriteAllBytes");
+    expect(cmd).toContain("@()");
+  });
+
+  it("writes a single-chunk file via WriteAllBytes", async () => {
+    const data = Buffer.from("hello BC");
+    mockFs.readFileSync.mockReturnValueOnce(data);
+    fakeExecOk(""); // execInContainer for single chunk
+    await (svc as any).writeFileToContainer("mybc", "C:\\host\\lic.flf", "C:\\run\\my\\lic.flf");
+    const cmd: string = mockExec.mock.calls[0][0];
+    expect(cmd).toContain("WriteAllBytes");
+    expect(cmd).toContain(data.toString("base64"));
+  });
+
+  it("writes a multi-chunk file using WriteAllBytes then FileStream append", async () => {
+    const data = Buffer.alloc(5_001, 0xAB); // 5001 bytes => 2 chunks
+    mockFs.readFileSync.mockReturnValueOnce(data);
+    fakeExecOk(""); // chunk 1
+    fakeExecOk(""); // chunk 2
+    await (svc as any).writeFileToContainer("mybc", "C:\\host\\big.bak", "C:\\run\\big.bak");
+    expect(mockExec).toHaveBeenCalledTimes(2);
+    const firstCmd: string = mockExec.mock.calls[0][0];
+    const secondCmd: string = mockExec.mock.calls[1][0];
+    expect(firstCmd).toContain("WriteAllBytes");
+    expect(secondCmd).toContain("System.IO.File]::Open");
+    expect(secondCmd).toContain("Append");
+  });
+
+  it("escapes single quotes in container path", async () => {
+    const data = Buffer.from("x");
+    mockFs.readFileSync.mockReturnValueOnce(data);
     fakeExecOk("");
-    await (svc as any).copyToContainer("mybc", "C:\\temp\\file.app", "C:\\run\\my\\file.app");
-    expect(mockExec.mock.calls[0][0]).toBe(
-      'docker cp "C:\\temp\\file.app" mybc:C:\\run\\my\\file.app',
-    );
+    await (svc as any).writeFileToContainer("mybc", "C:\\host\\f.txt", "C:\\path with 'quotes'\\f.txt");
+    const cmd: string = mockExec.mock.calls[0][0];
+    expect(cmd).toContain("C:\\path with ''quotes''\\f.txt");
   });
 });
 
-describe("copyFromContainer", () => {
-  it("runs docker cp from container to host", async () => {
-    fakeExecOk("");
-    await (svc as any).copyFromContainer("mybc", "C:\\temp\\backup.bak", "D:\\backups\\backup.bak");
-    expect(mockExec.mock.calls[0][0]).toBe(
-      'docker cp mybc:C:\\temp\\backup.bak "D:\\backups\\backup.bak"',
+// ─── readFileFromContainer (private) ─────────────────────────────
+
+describe("readFileFromContainer", () => {
+  it("reads a file in a single chunk and writes to host", async () => {
+    const fileContent = Buffer.from("recovered data");
+    const b64 = fileContent.toString("base64");
+    fakeExecOk(`${fileContent.length}\n`); // Get-Item Length
+    fakeExecOk(`${b64}\n`);                // single read chunk
+    mockFs.writeFileSync.mockImplementation(() => {});
+    await (svc as any).readFileFromContainer("mybc", "C:\\run\\out.bak", "D:\\local\\out.bak");
+    expect(mockFs.writeFileSync).toHaveBeenCalledWith(
+      "D:\\local\\out.bak",
+      expect.any(Buffer),
     );
+    const written: Buffer = (mockFs.writeFileSync as jest.Mock).mock.calls[0][1];
+    expect(written.toString()).toBe("recovered data");
+  });
+
+  it("concatenates multiple chunks correctly", async () => {
+    const chunk1 = Buffer.alloc(50_000, 0x01);
+    const chunk2 = Buffer.alloc(100, 0x02);
+    const fileSize = 50_100;
+    fakeExecOk(`${fileSize}\n`);
+    fakeExecOk(`${chunk1.toString("base64")}\n`);
+    fakeExecOk(`${chunk2.toString("base64")}\n`);
+    mockFs.writeFileSync.mockImplementation(() => {});
+    await (svc as any).readFileFromContainer("mybc", "C:\\run\\big.bak", "D:\\big.bak");
+    const written: Buffer = (mockFs.writeFileSync as jest.Mock).mock.calls[0][1];
+    expect(written.length).toBe(50_100);
+    expect(written[0]).toBe(0x01);
+    expect(written[50_000]).toBe(0x02);
   });
 });
 

--- a/src/docker/bcContainerService.test.ts
+++ b/src/docker/bcContainerService.test.ts
@@ -693,6 +693,68 @@ describe("deleteProfile", () => {
   });
 });
 
+// ─── backupDatabase edition detection ────────────────────────────
+
+describe("backupDatabase edition detection", () => {
+  beforeEach(() => {
+    (vscode.window.showSaveDialog as jest.Mock).mockResolvedValue(
+      vscode.Uri.file("C:\\backups\\mybc_backup.bak"),
+    );
+  });
+
+  it("uses WITH FORMAT COMPRESSION on non-Express editions", async () => {
+    fakeExecOk(JSON.stringify({ ServerInstance: "BC", DatabaseName: "MyDB" })); // getContainerInfo
+    fakeExecOk("3\n"); // EngineEdition = 3 (Enterprise)
+    fakeExecOk("");    // New-Item temp dir
+    fakeExecOk("");    // BACKUP DATABASE
+    // readFileFromContainer: size query + read chunk
+    fakeExecOk("0\n");
+    mockFs.writeFileSync.mockImplementation(() => {});
+    fakeExecOk(""); // cleanup
+
+    await svc.backupDatabase("mybc");
+
+    const calls: string[] = mockExec.mock.calls.map((c: any[]) => c[0] as string);
+    const backupCall = calls.find(c => c.includes("BACKUP DATABASE"));
+    expect(backupCall).toBeDefined();
+    expect(backupCall).toContain("WITH FORMAT, COMPRESSION");
+  });
+
+  it("uses WITH FORMAT only on SQL Server Express (EngineEdition 4)", async () => {
+    fakeExecOk(JSON.stringify({ ServerInstance: "BC", DatabaseName: "MyDB" })); // getContainerInfo
+    fakeExecOk("4\n"); // EngineEdition = 4 (Express)
+    fakeExecOk("");    // New-Item temp dir
+    fakeExecOk("");    // BACKUP DATABASE
+    fakeExecOk("0\n");
+    mockFs.writeFileSync.mockImplementation(() => {});
+    fakeExecOk(""); // cleanup
+
+    await svc.backupDatabase("mybc");
+
+    const calls: string[] = mockExec.mock.calls.map((c: any[]) => c[0] as string);
+    const backupCall = calls.find(c => c.includes("BACKUP DATABASE"));
+    expect(backupCall).toBeDefined();
+    expect(backupCall).not.toContain("COMPRESSION");
+  });
+
+  it("defaults to WITH FORMAT COMPRESSION when edition check fails", async () => {
+    fakeExecOk(JSON.stringify({ ServerInstance: "BC", DatabaseName: "MyDB" })); // getContainerInfo
+    fakeExecFail("cmdlet not found"); // edition check fails
+    fakeExecOk("");    // New-Item temp dir
+    fakeExecOk("");    // BACKUP DATABASE
+    fakeExecOk("0\n");
+    mockFs.writeFileSync.mockImplementation(() => {});
+    fakeExecOk(""); // cleanup
+
+    await svc.backupDatabase("mybc");
+
+    const calls: string[] = mockExec.mock.calls.map((c: any[]) => c[0] as string);
+    const backupCall = calls.find(c => c.includes("BACKUP DATABASE"));
+    expect(backupCall).toBeDefined();
+    expect(backupCall).toContain("WITH FORMAT, COMPRESSION");
+  });
+});
+
 // ─── getContainerStats ───────────────────────────────────────────
 
 describe("getContainerStats", () => {

--- a/src/docker/bcContainerService.test.ts
+++ b/src/docker/bcContainerService.test.ts
@@ -55,6 +55,44 @@ beforeEach(() => {
   svc = new BcContainerService(docker);
 });
 
+// ─── cleanPsError (private static, accessed via any) ─────────────
+
+describe("cleanPsError", () => {
+  const clean = (raw: string) => (BcContainerService as any).cleanPsError(raw);
+
+  it("returns empty string for empty input", () => {
+    expect(clean("")).toBe("");
+  });
+
+  it("strips ANSI escape sequences", () => {
+    expect(clean("\x1b[31;1mSome error\x1b[0m")).toBe("Some error");
+  });
+
+  it("extracts the value line from a structured PowerShell error", () => {
+    const raw = [
+      "\x1b[31;1mImport-NAVServerLicense : \x1b[0m",
+      "Line |",
+      "  15 |     $output = Import-NAVServerLicense @cmdletArgs;",
+      "     |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~",
+      "     | Your program license has expired.",
+    ].join("\n");
+    expect(clean(raw)).toBe("Import-NAVServerLicense: Your program license has expired.");
+  });
+
+  it("skips underline-only lines when extracting value", () => {
+    const raw = "Set-NAVServerInstance : \n     |     ~~~~~~~~~~~\n     | Service not found.";
+    expect(clean(raw)).toBe("Set-NAVServerInstance: Service not found.");
+  });
+
+  it("falls back to first non-empty line when no PS structure found", () => {
+    expect(clean("container not found\nmore details")).toBe("container not found");
+  });
+
+  it("handles plain stderr with no ANSI and no PS structure", () => {
+    expect(clean("permission denied")).toBe("permission denied");
+  });
+});
+
 // ─── exec (private, accessed via `any`) ──────────────────────────
 
 describe("exec", () => {
@@ -79,9 +117,14 @@ describe("exec", () => {
     );
   });
 
-  it("rejects with stderr message on error", async () => {
+  it("rejects with cleaned stderr message on error", async () => {
     fakeExecFail("permission denied");
     await expect((svc as any).exec("bad-cmd")).rejects.toThrow("permission denied");
+  });
+
+  it("strips ANSI codes from stderr when rejecting", async () => {
+    fakeExecFail("\x1b[31;1mContainer not found\x1b[0m");
+    await expect((svc as any).exec("bad-cmd")).rejects.toThrow("Container not found");
   });
 
   it("rejects with err.message when stderr is empty", async () => {

--- a/src/docker/bcContainerService.test.ts
+++ b/src/docker/bcContainerService.test.ts
@@ -3,7 +3,7 @@
  *
  * Tests focus on:
  *  - Shell helpers (exec, execInContainer) via casting to `any`
- *  - File transfer helpers (writeFileToContainer, readFileFromContainer) via Base64 chunking
+ *  - File transfer helpers (writeFileToContainer, readFileFromContainer) via spawn streaming
  *  - Cached metadata (getContainerInfo with TTL)
  *  - Copy Container IP
  *  - Volume parsing (getVolumes, removeVolume)
@@ -12,17 +12,20 @@
  *  - Export / Import
  */
 
-import { exec } from "child_process";
+import { exec, spawn } from "child_process";
+import { EventEmitter } from "events";
 import * as fs from "fs";
 import * as vscode from "vscode";
 import { BcContainerService } from "./bcContainerService";
 
 jest.mock("child_process", () => ({
   exec: jest.fn(),
+  spawn: jest.fn(),
 }));
 jest.mock("fs");
 
 const mockExec = exec as unknown as jest.Mock;
+const mockSpawn = spawn as unknown as jest.Mock;
 const mockFs = fs as jest.Mocked<typeof fs>;
 
 /** Simulate a successful child_process.exec call. */
@@ -37,6 +40,69 @@ function fakeExecFail(stderr: string) {
   mockExec.mockImplementationOnce((_cmd: string, _opts: any, cb: Function) => {
     cb(new Error("exec error"), "", stderr);
   });
+}
+
+/** Create a mock proc returned by spawn() that fires close(0) after stdout data. */
+function makeSpawnProc() {
+  const proc = new EventEmitter() as any;
+  proc.stdout = new EventEmitter() as any;
+  proc.stdout.pause = jest.fn();
+  proc.stdout.resume = jest.fn();
+  proc.stderr = new EventEmitter();
+  proc.stdin = { write: jest.fn().mockReturnValue(true), end: jest.fn(), once: jest.fn() };
+  proc.kill = jest.fn();
+  return proc;
+}
+
+/** Simulate a successful spawn: emits stdout data then close(0). */
+function fakeSpawnOk(stdoutData = "") {
+  const proc = makeSpawnProc();
+  mockSpawn.mockImplementationOnce(() => {
+    setImmediate(() => {
+      if (stdoutData) {
+        proc.stdout.emit("data", Buffer.from(stdoutData, "ascii"));
+      }
+      proc.emit("close", 0);
+    });
+    return proc;
+  });
+  return proc;
+}
+
+/** Simulate a failing spawn: emits stderr then close(code). */
+function fakeSpawnFail(stderrData: string, code = 1) {
+  const proc = makeSpawnProc();
+  mockSpawn.mockImplementationOnce(() => {
+    setImmediate(() => {
+      if (stderrData) {
+        proc.stderr.emit("data", Buffer.from(stderrData));
+      }
+      proc.emit("close", code);
+    });
+    return proc;
+  });
+  return proc;
+}
+
+/** Create a mock fs.WriteStream that calls its end() callback asynchronously. */
+function makeWriteStream() {
+  const ws = new EventEmitter() as any;
+  ws.write = jest.fn().mockReturnValue(true);
+  ws.end = jest.fn((cb?: () => void) => { if (cb) { setImmediate(cb); } return ws; });
+  ws.destroy = jest.fn();
+  return ws;
+}
+
+/** Create a mock fs.ReadStream that emits content then ends asynchronously. */
+function makeReadStream(content: Buffer) {
+  const rs = new EventEmitter() as any;
+  rs.pause = jest.fn();
+  rs.resume = jest.fn();
+  setImmediate(() => {
+    if (content.length > 0) { rs.emit("data", content); }
+    rs.emit("end");
+  });
+  return rs;
 }
 
 /** Create a minimal mock of DockerService. */
@@ -176,80 +242,98 @@ describe("execInContainer", () => {
 // ─── writeFileToContainer (private) ──────────────────────────────
 
 describe("writeFileToContainer", () => {
-  it("writes an empty file via WriteAllBytes with empty array", async () => {
-    mockFs.readFileSync.mockReturnValueOnce(Buffer.alloc(0));
-    fakeExecOk(""); // execInContainer for empty file
-    await (svc as any).writeFileToContainer("mybc", "C:\\host\\empty.txt", "C:\\run\\my\\empty.txt");
-    const cmd: string = mockExec.mock.calls[0][0];
-    expect(cmd).toContain("WriteAllBytes");
-    expect(cmd).toContain("@()");
-  });
-
-  it("writes a single-chunk file via WriteAllBytes", async () => {
-    const data = Buffer.from("hello BC");
-    mockFs.readFileSync.mockReturnValueOnce(data);
-    fakeExecOk(""); // execInContainer for single chunk
+  it("spawns docker exec -i and pipes base64 to stdin", async () => {
+    const content = Buffer.from("hello BC");
+    mockFs.createReadStream.mockReturnValueOnce(makeReadStream(content) as any);
+    const proc = fakeSpawnOk();
     await (svc as any).writeFileToContainer("mybc", "C:\\host\\lic.flf", "C:\\run\\my\\lic.flf");
-    const cmd: string = mockExec.mock.calls[0][0];
-    expect(cmd).toContain("WriteAllBytes");
-    expect(cmd).toContain(data.toString("base64"));
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["-i", "mybc", "powershell"]),
+    );
+    expect(proc.stdin.end).toHaveBeenCalled();
   });
 
-  it("writes a multi-chunk file using WriteAllBytes then FileStream append", async () => {
-    const data = Buffer.alloc(5_001, 0xAB); // 5001 bytes => 2 chunks
-    mockFs.readFileSync.mockReturnValueOnce(data);
-    fakeExecOk(""); // chunk 1
-    fakeExecOk(""); // chunk 2
-    await (svc as any).writeFileToContainer("mybc", "C:\\host\\big.bak", "C:\\run\\big.bak");
-    expect(mockExec).toHaveBeenCalledTimes(2);
-    const firstCmd: string = mockExec.mock.calls[0][0];
-    const secondCmd: string = mockExec.mock.calls[1][0];
-    expect(firstCmd).toContain("WriteAllBytes");
-    expect(secondCmd).toContain("System.IO.File]::Open");
-    expect(secondCmd).toContain("Append");
+  it("writes base64-encoded content as a newline-terminated line to stdin", async () => {
+    const content = Buffer.from("hello");
+    mockFs.createReadStream.mockReturnValueOnce(makeReadStream(content) as any);
+    const proc = fakeSpawnOk();
+    await (svc as any).writeFileToContainer("mybc", "C:\\host\\f.txt", "C:\\run\\f.txt");
+    // Decode all base64 lines (each chunk is a multiple of 3 raw bytes so
+    // only the final chunk carries '=' padding — safe to concatenate).
+    const allLines: string = proc.stdin.write.mock.calls
+      .map((c: any[]) => (c[0] as string).replace(/\n$/, ""))
+      .join("");
+    expect(Buffer.from(allLines, "base64")).toEqual(content);
+    // Each write ends with a newline
+    const lastWrite: string = proc.stdin.write.mock.calls.at(-1)[0];
+    expect(lastWrite).toMatch(/\n$/);
   });
 
-  it("escapes single quotes in container path", async () => {
-    const data = Buffer.from("x");
-    mockFs.readFileSync.mockReturnValueOnce(data);
-    fakeExecOk("");
+  it("completes without writing data for an empty file", async () => {
+    mockFs.createReadStream.mockReturnValueOnce(makeReadStream(Buffer.alloc(0)) as any);
+    const proc = fakeSpawnOk();
+    await (svc as any).writeFileToContainer("mybc", "C:\\host\\empty.txt", "C:\\run\\empty.txt");
+    // No base64 lines, only stdin.end() called
+    expect(proc.stdin.end).toHaveBeenCalled();
+    const written: string = proc.stdin.write.mock.calls.map((c: any[]) => c[0]).join("");
+    expect(written).toBe("");
+  });
+
+  it("escapes single quotes in the container path", async () => {
+    mockFs.createReadStream.mockReturnValueOnce(makeReadStream(Buffer.from("x")) as any);
+    fakeSpawnOk();
     await (svc as any).writeFileToContainer("mybc", "C:\\host\\f.txt", "C:\\path with 'quotes'\\f.txt");
-    const cmd: string = mockExec.mock.calls[0][0];
-    expect(cmd).toContain("C:\\path with ''quotes''\\f.txt");
+    const args: string[] = mockSpawn.mock.calls[0][1];
+    expect(args.join(" ")).toContain("''quotes''");
+  });
+
+  it("rejects when the container process exits with a non-zero code", async () => {
+    mockFs.createReadStream.mockReturnValueOnce(makeReadStream(Buffer.from("data")) as any);
+    fakeSpawnFail("access denied");
+    await expect(
+      (svc as any).writeFileToContainer("mybc", "C:\\host\\f.txt", "C:\\run\\f.txt"),
+    ).rejects.toThrow("access denied");
   });
 });
 
 // ─── readFileFromContainer (private) ─────────────────────────────
 
 describe("readFileFromContainer", () => {
-  it("reads a file in a single chunk and writes to host", async () => {
-    const fileContent = Buffer.from("recovered data");
-    const b64 = fileContent.toString("base64");
-    fakeExecOk(`${fileContent.length}\n`); // Get-Item Length
-    fakeExecOk(`${b64}\n`);                // single read chunk
-    mockFs.writeFileSync.mockImplementation(() => {});
+  it("decodes base64 stdout and writes raw bytes to the host file", async () => {
+    const content = Buffer.from("recovered data");
+    const ws = makeWriteStream();
+    mockFs.createWriteStream.mockReturnValueOnce(ws as any);
+    fakeSpawnOk(content.toString("base64"));
     await (svc as any).readFileFromContainer("mybc", "C:\\run\\out.bak", "D:\\local\\out.bak");
-    expect(mockFs.writeFileSync).toHaveBeenCalledWith(
-      "D:\\local\\out.bak",
-      expect.any(Buffer),
+    const written: Buffer = Buffer.concat(
+      ws.write.mock.calls.map((c: any[]) => c[0] as Buffer),
     );
-    const written: Buffer = (mockFs.writeFileSync as jest.Mock).mock.calls[0][1];
     expect(written.toString()).toBe("recovered data");
   });
 
-  it("concatenates multiple chunks correctly", async () => {
-    const chunk1 = Buffer.alloc(50_000, 0x01);
-    const chunk2 = Buffer.alloc(100, 0x02);
-    const fileSize = 50_100;
-    fakeExecOk(`${fileSize}\n`);
-    fakeExecOk(`${chunk1.toString("base64")}\n`);
-    fakeExecOk(`${chunk2.toString("base64")}\n`);
-    mockFs.writeFileSync.mockImplementation(() => {});
+  it("streams large files without loading all into memory", async () => {
+    const chunk1 = Buffer.alloc(49_152, 0x01); // 48 KB — no padding
+    const chunk2 = Buffer.alloc(100, 0x02);    // leftover — padded
+    const b64 = Buffer.concat([chunk1, chunk2]).toString("base64");
+    const ws = makeWriteStream();
+    mockFs.createWriteStream.mockReturnValueOnce(ws as any);
+    fakeSpawnOk(b64);
     await (svc as any).readFileFromContainer("mybc", "C:\\run\\big.bak", "D:\\big.bak");
-    const written: Buffer = (mockFs.writeFileSync as jest.Mock).mock.calls[0][1];
-    expect(written.length).toBe(50_100);
+    const written = Buffer.concat(ws.write.mock.calls.map((c: any[]) => c[0] as Buffer));
+    expect(written.length).toBe(49_252);
     expect(written[0]).toBe(0x01);
-    expect(written[50_000]).toBe(0x02);
+    expect(written[49_152]).toBe(0x02);
+  });
+
+  it("rejects and cleans up the partial file when the process fails", async () => {
+    const ws = makeWriteStream();
+    mockFs.createWriteStream.mockReturnValueOnce(ws as any);
+    fakeSpawnFail("file not found");
+    await expect(
+      (svc as any).readFileFromContainer("mybc", "C:\\run\\missing.bak", "D:\\missing.bak"),
+    ).rejects.toThrow("file not found");
+    expect(ws.destroy).toHaveBeenCalled();
   });
 });
 
@@ -707,9 +791,9 @@ describe("backupDatabase edition detection", () => {
     fakeExecOk("3\n"); // EngineEdition = 3 (Enterprise)
     fakeExecOk("");    // New-Item temp dir
     fakeExecOk("");    // BACKUP DATABASE
-    // readFileFromContainer: size query + read chunk
-    fakeExecOk("0\n");
-    mockFs.writeFileSync.mockImplementation(() => {});
+    const ws = makeWriteStream();
+    mockFs.createWriteStream.mockReturnValueOnce(ws as any);
+    fakeSpawnOk(""); // readFileFromContainer
     fakeExecOk(""); // cleanup
 
     await svc.backupDatabase("mybc");
@@ -725,8 +809,9 @@ describe("backupDatabase edition detection", () => {
     fakeExecOk("4\n"); // EngineEdition = 4 (Express)
     fakeExecOk("");    // New-Item temp dir
     fakeExecOk("");    // BACKUP DATABASE
-    fakeExecOk("0\n");
-    mockFs.writeFileSync.mockImplementation(() => {});
+    const ws = makeWriteStream();
+    mockFs.createWriteStream.mockReturnValueOnce(ws as any);
+    fakeSpawnOk(""); // readFileFromContainer
     fakeExecOk(""); // cleanup
 
     await svc.backupDatabase("mybc");
@@ -742,8 +827,9 @@ describe("backupDatabase edition detection", () => {
     fakeExecFail("cmdlet not found"); // edition check fails
     fakeExecOk("");    // New-Item temp dir
     fakeExecOk("");    // BACKUP DATABASE
-    fakeExecOk("0\n");
-    mockFs.writeFileSync.mockImplementation(() => {});
+    const ws = makeWriteStream();
+    mockFs.createWriteStream.mockReturnValueOnce(ws as any);
+    fakeSpawnOk(""); // readFileFromContainer
     fakeExecOk(""); // cleanup
 
     await svc.backupDatabase("mybc");

--- a/src/docker/bcContainerService.ts
+++ b/src/docker/bcContainerService.ts
@@ -12,6 +12,11 @@ const EXEC_TIMEOUT_MS = 120_000; // BC operations can be slow
 const BC_SERVER_INSTANCE = "BC";
 const CONTAINER_TEMP = "C:\\run\\my";
 
+/** Max bytes per write chunk: base64 of 5 000 bytes is ~6 700 chars, safely under the 8 191-char cmd.exe command line limit. */
+const CONTAINER_WRITE_CHUNK = 5_000;
+/** Max bytes per read chunk: 50 000 bytes produces ~66 KB of base64 stdout, well under the 10 MB exec buffer. */
+const CONTAINER_READ_CHUNK = 50_000;
+
 /**
  * Import the NAV/BC management module inside the container.
  * Required because we use `-NoProfile` to avoid slow profile loading
@@ -25,7 +30,8 @@ const NAV_MODULE_IMPORT =
 
 /**
  * BC-specific operations that run inside a Business Central container
- * via `docker exec` + PowerShell cmdlets or `docker cp`.
+ * via `docker exec` + PowerShell cmdlets. All file transfers use chunked
+ * Base64 over docker exec to support both Process and Hyper-V isolation.
  *
  * This keeps dockerService.ts focused on generic Docker operations.
  */
@@ -76,22 +82,105 @@ export class BcContainerService {
     );
   }
 
-  /** Copy a file from host into a container. */
-  private async copyToContainer(
-    containerName: string,
-    hostPath: string,
-    containerPath: string,
-  ): Promise<void> {
-    await this.exec(`docker cp "${hostPath}" ${containerName}:${containerPath}`);
+  /** Escape single quotes in a path for use inside a PowerShell single-quoted string. */
+  private static escapePsPath(p: string): string {
+    return p.replace(/'/g, "''");
   }
 
-  /** Copy a file from a container to host. */
-  private async copyFromContainer(
+  /**
+   * Write a host file into a container using chunked Base64 via docker exec.
+   * Works with both Hyper-V and Process isolation containers.
+   * docker cp is not used because Hyper-V containers block direct filesystem operations.
+   */
+  private async writeFileToContainer(
+    containerName: string,
+    hostPath: string,
+    containerPath: string,
+  ): Promise<void> {
+    const content = fs.readFileSync(hostPath);
+    const ep = BcContainerService.escapePsPath(containerPath);
+
+    if (content.length === 0) {
+      await this.execInContainer(containerName, `[System.IO.File]::WriteAllBytes('${ep}',@())`, 10_000);
+      return;
+    }
+
+    for (let offset = 0; offset < content.length; offset += CONTAINER_WRITE_CHUNK) {
+      const b64 = content.slice(offset, offset + CONTAINER_WRITE_CHUNK).toString("base64");
+      const ps = offset === 0
+        ? `[System.IO.File]::WriteAllBytes('${ep}',[System.Convert]::FromBase64String('${b64}'))`
+        : `$s=[System.IO.File]::Open('${ep}',[System.IO.FileMode]::Append,[System.IO.FileAccess]::Write);$b=[System.Convert]::FromBase64String('${b64}');$s.Write($b,0,$b.Length);$s.Close()`;
+      await this.execInContainer(containerName, ps, 30_000);
+    }
+  }
+
+  /**
+   * Read a file from a container to the host using chunked Base64 via docker exec.
+   * Works with both Hyper-V and Process isolation containers.
+   */
+  private async readFileFromContainer(
     containerName: string,
     containerPath: string,
     hostPath: string,
   ): Promise<void> {
-    await this.exec(`docker cp ${containerName}:${containerPath} "${hostPath}"`);
+    const ep = BcContainerService.escapePsPath(containerPath);
+    const sizeStr = await this.execInContainer(
+      containerName,
+      `(Get-Item '${ep}').Length`,
+      10_000,
+    );
+    const fileSize = parseInt(sizeStr.trim(), 10);
+    const parts: Buffer[] = [];
+
+    for (let offset = 0; offset < fileSize; offset += CONTAINER_READ_CHUNK) {
+      const len = Math.min(CONTAINER_READ_CHUNK, fileSize - offset);
+      const b64 = await this.execInContainer(
+        containerName,
+        `$f=[System.IO.File]::OpenRead('${ep}');$f.Seek(${offset},[System.IO.SeekOrigin]::Begin)|Out-Null;$b=New-Object byte[] ${len};$f.Read($b,0,${len})|Out-Null;$f.Close();[System.Convert]::ToBase64String($b)`,
+        30_000,
+      );
+      parts.push(Buffer.from(b64.trim(), "base64"));
+    }
+
+    fs.writeFileSync(hostPath, Buffer.concat(parts));
+  }
+
+  /**
+   * Copy a host directory into a container using a zip transfer via docker exec.
+   * Compresses the directory on the host, transfers the zip in Base64 chunks,
+   * and expands it inside the container. Works with Hyper-V containers.
+   */
+  private async writeDirToContainer(
+    containerName: string,
+    hostDir: string,
+    containerDir: string,
+  ): Promise<void> {
+    const zipPath = path.join(os.tmpdir(), `bcm_${Date.now()}.zip`);
+    const eZip = BcContainerService.escapePsPath(zipPath);
+    const eHostDir = BcContainerService.escapePsPath(hostDir);
+    const eContainerDir = BcContainerService.escapePsPath(containerDir);
+    const containerZip = `${containerDir}.zip`;
+    const eContainerZip = BcContainerService.escapePsPath(containerZip);
+
+    try {
+      await this.exec(
+        `powershell -NoProfile -Command "Compress-Archive -Path '${eHostDir}\\*' -DestinationPath '${eZip}' -Force"`,
+        60_000,
+      );
+      await this.execInContainer(
+        containerName,
+        `New-Item -Path '${eContainerDir}' -ItemType Directory -Force | Out-Null`,
+        15_000,
+      );
+      await this.writeFileToContainer(containerName, zipPath, containerZip);
+      await this.execInContainer(
+        containerName,
+        `Expand-Archive -Path '${eContainerZip}' -DestinationPath '${eContainerDir}' -Force; Remove-Item '${eContainerZip}' -Force -ErrorAction SilentlyContinue`,
+        120_000,
+      );
+    } finally {
+      fs.rmSync(zipPath, { force: true });
+    }
   }
 
   // ── v1.1: Copy Container IP ──────────────────────────────────
@@ -136,8 +225,8 @@ export class BcContainerService {
         ]);
 
         // Step 2: Copy .app file into container
-        progress.report({ message: "Copying app to container…" });
-        await this.copyToContainer(containerName, hostPath, containerPath);
+        progress.report({ message: "Copying app to container..." });
+        await this.writeFileToContainer(containerName, hostPath, containerPath);
 
         // Step 3: Publish the app
         progress.report({ message: "Publishing app…" });
@@ -217,12 +306,12 @@ export class BcContainerService {
     await vscode.window.withProgress(
       { location: vscode.ProgressLocation.Notification, title: "Importing license…" },
       async (progress) => {
-        progress.report({ message: "Copying license to container…" });
+        progress.report({ message: "Copying license to container..." });
         await this.execInContainer(
           containerName,
           `if (!(Test-Path '${CONTAINER_TEMP}')) { New-Item -Path '${CONTAINER_TEMP}' -ItemType Directory -Force | Out-Null }`,
         );
-        await this.copyToContainer(containerName, hostPath, containerPath);
+        await this.writeFileToContainer(containerName, hostPath, containerPath);
 
         const serverInstance = await this.getServerInstance(containerName);
 
@@ -364,8 +453,8 @@ export class BcContainerService {
           600_000, // 10 min timeout for large DBs
         );
 
-        progress.report({ message: "Copying backup to host…" });
-        await this.copyFromContainer(containerName, containerBakPath, saveUri.fsPath);
+        progress.report({ message: "Copying backup to host..." });
+        await this.readFileFromContainer(containerName, containerBakPath, saveUri.fsPath);
 
         // Cleanup inside container
         await this.execInContainer(
@@ -410,8 +499,8 @@ export class BcContainerService {
           ),
         ]);
 
-        progress.report({ message: "Copying backup to container…" });
-        await this.copyToContainer(containerName, hostPath, containerBakPath);
+        progress.report({ message: "Copying backup to container..." });
+        await this.writeFileToContainer(containerName, hostPath, containerBakPath);
 
         progress.report({ message: "Stopping service tier…" });
         await this.execNavInContainer(
@@ -818,9 +907,9 @@ export class BcContainerService {
         }
 
         // Copy workspace to container
-        progress.report({ message: "Copying project to container…" });
+        progress.report({ message: "Copying project to container..." });
         const containerProjectPath = `C:\\temp\\alproject_${Date.now()}`;
-        await this.exec(`docker cp "${targetFolder.uri.fsPath}" ${containerName}:${containerProjectPath}`);
+        await this.writeDirToContainer(containerName, targetFolder.uri.fsPath, containerProjectPath);
 
         // Find symbol files
         const symbolPath = await this.execInContainer(
@@ -850,9 +939,9 @@ export class BcContainerService {
 
         if (outputExists.trim().toLowerCase() === "true") {
           // Copy back to host
-          progress.report({ message: "Copying compiled app to host…" });
+          progress.report({ message: "Copying compiled app to host..." });
           const outputPath = path.join(targetFolder.uri.fsPath, "output.app");
-          await this.copyFromContainer(containerName, `${containerProjectPath}\\output.app`, outputPath);
+          await this.readFileFromContainer(containerName, `${containerProjectPath}\\output.app`, outputPath);
           vscode.window.showInformationMessage(`Compiled app saved to ${outputPath}`);
         } else {
           vscode.window.showWarningMessage("Compilation completed with errors. Check the output channel.");

--- a/src/docker/bcContainerService.ts
+++ b/src/docker/bcContainerService.ts
@@ -1,4 +1,4 @@
-import { exec } from "child_process";
+import { exec, spawn } from "child_process";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -12,10 +12,17 @@ const EXEC_TIMEOUT_MS = 120_000; // BC operations can be slow
 const BC_SERVER_INSTANCE = "BC";
 const CONTAINER_TEMP = "C:\\run\\my";
 
-/** Max bytes per write chunk: base64 of 5 000 bytes is ~6 700 chars, safely under the 8 191-char cmd.exe command line limit. */
-const CONTAINER_WRITE_CHUNK = 5_000;
-/** Max bytes per read chunk: 50 000 bytes produces ~66 KB of base64 stdout, well under the 10 MB exec buffer. */
-const CONTAINER_READ_CHUNK = 50_000;
+/**
+ * Chunk size for streaming file transfers between host and container.
+ * 49 152 bytes = 48 KB = 16 384 × 3, so every full chunk base64-encodes
+ * with zero padding characters. Only the final (possibly smaller) chunk
+ * may carry '=' padding. This lets the container and host decode each
+ * chunk independently without boundary ambiguity.
+ */
+const FILE_TRANSFER_CHUNK = 49_152;
+
+/** Maximum wall-clock time for a single file transfer (30 minutes). */
+const FILE_TRANSFER_TIMEOUT_MS = 1_800_000;
 
 /**
  * Import the NAV/BC management module inside the container.
@@ -114,61 +121,176 @@ export class BcContainerService {
   }
 
   /**
-   * Write a host file into a container using chunked Base64 via docker exec.
-   * Works with both Hyper-V and Process isolation containers.
-   * docker cp is not used because Hyper-V containers block direct filesystem operations.
+   * Write a host file into a container by streaming base64-encoded lines
+   * through a single `docker exec -i` stdin pipe.
+   *
+   * A single spawn replaces N sequential exec calls, eliminating per-chunk
+   * PowerShell process startup overhead (~400 ms each).
+   *
+   * Protocol: the host reads the file in FILE_TRANSFER_CHUNK-byte slices
+   * (multiple of 3 bytes so each slice produces clean base64 without '='
+   * padding). Each slice is written as a base64 line to stdin. The container
+   * PowerShell reads each line, decodes it, and appends the raw bytes to the
+   * target file. EOF (stdin close) signals the container to flush and exit.
+   *
+   * Backpressure: if proc.stdin signals full, the host read stream is paused
+   * until the drain event fires, preventing unbounded memory growth.
    */
-  private async writeFileToContainer(
+  private writeFileToContainer(
     containerName: string,
     hostPath: string,
     containerPath: string,
+    timeoutMs = FILE_TRANSFER_TIMEOUT_MS,
   ): Promise<void> {
-    const content = fs.readFileSync(hostPath);
     const ep = BcContainerService.escapePsPath(containerPath);
+    const psCmd =
+      `$s=[IO.File]::Create('${ep}');` +
+      `while(($l=[Console]::In.ReadLine()) -ne $null){` +
+      `$t=$l.Trim();if($t.Length -gt 0){$b=[Convert]::FromBase64String($t);$s.Write($b,0,$b.Length)}};` +
+      `$s.Dispose()`;
 
-    if (content.length === 0) {
-      await this.execInContainer(containerName, `[System.IO.File]::WriteAllBytes('${ep}',@())`, 10_000);
-      return;
-    }
+    return new Promise<void>((resolve, reject) => {
+      const proc = spawn("docker", ["exec", "-i", containerName, "powershell", "-NoProfile", "-Command", psCmd]);
+      let stderr = "";
+      let settled = false;
 
-    for (let offset = 0; offset < content.length; offset += CONTAINER_WRITE_CHUNK) {
-      const b64 = content.slice(offset, offset + CONTAINER_WRITE_CHUNK).toString("base64");
-      const ps = offset === 0
-        ? `[System.IO.File]::WriteAllBytes('${ep}',[System.Convert]::FromBase64String('${b64}'))`
-        : `$s=[System.IO.File]::Open('${ep}',[System.IO.FileMode]::Append,[System.IO.FileAccess]::Write);$b=[System.Convert]::FromBase64String('${b64}');$s.Write($b,0,$b.Length);$s.Close()`;
-      await this.execInContainer(containerName, ps, 30_000);
-    }
+      const fail = (err: Error) => {
+        if (settled) { return; }
+        settled = true;
+        proc.kill();
+        reject(err);
+      };
+
+      const timer = setTimeout(
+        () => fail(new Error("File transfer timed out")),
+        timeoutMs,
+      );
+
+      proc.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
+      proc.on("error", (err: Error) => { clearTimeout(timer); fail(err); });
+      proc.on("close", (code: number | null) => {
+        clearTimeout(timer);
+        if (settled) { return; }
+        settled = true;
+        if (code !== 0) {
+          reject(new Error(BcContainerService.cleanPsError(stderr) || `Transfer process exited with code ${code}`));
+        } else {
+          resolve();
+        }
+      });
+
+      const readStream = fs.createReadStream(hostPath, { highWaterMark: FILE_TRANSFER_CHUNK });
+      let pending = Buffer.alloc(0);
+
+      readStream.on("data", (chunk: Buffer) => {
+        const buf = pending.length ? Buffer.concat([pending, chunk]) : chunk;
+        const usable = buf.length - (buf.length % 3);
+        if (usable > 0) {
+          const canContinue = proc.stdin.write(buf.slice(0, usable).toString("base64") + "\n");
+          pending = buf.slice(usable);
+          if (!canContinue) {
+            readStream.pause();
+            proc.stdin.once("drain", () => readStream.resume());
+          }
+        } else {
+          pending = buf;
+        }
+      });
+
+      readStream.on("end", () => {
+        if (pending.length > 0) {
+          proc.stdin.write(pending.toString("base64") + "\n");
+        }
+        proc.stdin.end();
+      });
+
+      readStream.on("error", (err: Error) => { clearTimeout(timer); fail(err); });
+    });
   }
 
   /**
-   * Read a file from a container to the host using chunked Base64 via docker exec.
-   * Works with both Hyper-V and Process isolation containers.
+   * Read a file from a container to the host by streaming base64-encoded
+   * bytes through a single `docker exec` stdout pipe.
+   *
+   * A single spawn replaces N sequential exec calls, eliminating per-chunk
+   * PowerShell process startup overhead and the 10 MB exec maxBuffer limit.
+   *
+   * Protocol: the container PowerShell opens the file and reads it in
+   * FILE_TRANSFER_CHUNK-byte slices (multiple of 3 so all but the final
+   * slice produce clean, padding-free base64). Each slice is written to
+   * stdout via [Console]::Write() to bypass the PowerShell pipeline. The
+   * host decodes base64 quanta (groups of 4 chars = 3 raw bytes) on the fly
+   * and writes them directly to a write stream, keeping host memory usage
+   * proportional to the chunk size rather than the file size.
+   *
+   * Backpressure: if the write stream signals full, proc.stdout is paused
+   * until drain fires.
    */
-  private async readFileFromContainer(
+  private readFileFromContainer(
     containerName: string,
     containerPath: string,
     hostPath: string,
+    timeoutMs = FILE_TRANSFER_TIMEOUT_MS,
   ): Promise<void> {
     const ep = BcContainerService.escapePsPath(containerPath);
-    const sizeStr = await this.execInContainer(
-      containerName,
-      `(Get-Item '${ep}').Length`,
-      10_000,
-    );
-    const fileSize = parseInt(sizeStr.trim(), 10);
-    const parts: Buffer[] = [];
+    const psCmd =
+      `$f=[IO.File]::OpenRead('${ep}');` +
+      `$b=New-Object byte[] ${FILE_TRANSFER_CHUNK};` +
+      `while(($r=$f.Read($b,0,${FILE_TRANSFER_CHUNK}))-gt 0){[Console]::Write([Convert]::ToBase64String($b,0,$r))};` +
+      `$f.Close()`;
 
-    for (let offset = 0; offset < fileSize; offset += CONTAINER_READ_CHUNK) {
-      const len = Math.min(CONTAINER_READ_CHUNK, fileSize - offset);
-      const b64 = await this.execInContainer(
-        containerName,
-        `$f=[System.IO.File]::OpenRead('${ep}');$f.Seek(${offset},[System.IO.SeekOrigin]::Begin)|Out-Null;$b=New-Object byte[] ${len};$f.Read($b,0,${len})|Out-Null;$f.Close();[System.Convert]::ToBase64String($b)`,
-        30_000,
-      );
-      parts.push(Buffer.from(b64.trim(), "base64"));
-    }
+    return new Promise<void>((resolve, reject) => {
+      const proc = spawn("docker", ["exec", containerName, "powershell", "-NoProfile", "-Command", psCmd]);
+      const writeStream = fs.createWriteStream(hostPath);
+      let b64Buf = "";
+      let stderr = "";
+      let settled = false;
 
-    fs.writeFileSync(hostPath, Buffer.concat(parts));
+      const fail = (err: Error) => {
+        if (settled) { return; }
+        settled = true;
+        writeStream.destroy();
+        try { fs.unlinkSync(hostPath); } catch { /* ignore */ }
+        reject(err);
+      };
+
+      const timer = setTimeout(() => { proc.kill(); fail(new Error("File transfer timed out")); }, timeoutMs);
+
+      writeStream.on("error", (err: Error) => { clearTimeout(timer); proc.kill(); fail(err); });
+      proc.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
+
+      proc.stdout.on("data", (chunk: Buffer) => {
+        b64Buf += chunk.toString("ascii");
+        const usable = b64Buf.length - (b64Buf.length % 4);
+        if (usable >= 4) {
+          const decoded = Buffer.from(b64Buf.slice(0, usable), "base64");
+          b64Buf = b64Buf.slice(usable);
+          const canContinue = writeStream.write(decoded);
+          if (!canContinue) {
+            proc.stdout.pause();
+            writeStream.once("drain", () => proc.stdout.resume());
+          }
+        }
+      });
+
+      proc.on("error", (err: Error) => { clearTimeout(timer); fail(err); });
+      proc.on("close", (code: number | null) => {
+        clearTimeout(timer);
+        if (settled) { return; }
+        if (code !== 0) {
+          fail(new Error(BcContainerService.cleanPsError(stderr) || `Transfer process exited with code ${code}`));
+          return;
+        }
+        if (b64Buf.length > 0) {
+          writeStream.write(Buffer.from(b64Buf, "base64"));
+          b64Buf = "";
+        }
+        writeStream.end(() => {
+          settled = true;
+          resolve();
+        });
+      });
+    });
   }
 
   /**

--- a/src/docker/bcContainerService.ts
+++ b/src/docker/bcContainerService.ts
@@ -44,11 +44,37 @@ export class BcContainerService {
 
   // ── shell helper ─────────────────────────────────────────────
 
+  /**
+   * Strip ANSI escape sequences and reduce a multi-line PowerShell error to
+   * the single most relevant message. PowerShell writes the actual error value
+   * on a line formatted as "     | Error text here"; this extracts that line
+   * and prepends the cmdlet name from the first line.
+   *
+   * Falls back to the first non-empty line when no structured PS format is found.
+   */
+  private static cleanPsError(raw: string): string {
+    // eslint-disable-next-line no-control-regex
+    const clean = raw.replace(/\x1b\[[0-9;]*[A-Za-z]/g, "").trim();
+    if (!clean) { return ""; }
+
+    const lines = clean.split(/\r?\n/);
+    // PowerShell puts the actual error value on lines like "     | Your message."
+    // Lines with only tildes ("     |     ~~~~~") are underlines — skip them.
+    const valueLine = lines.find(l => /^\s*\|\s+[^~\s]/.test(l));
+    if (valueLine) {
+      const msg = valueLine.replace(/^\s*\|\s+/, "").trim();
+      const cmdlet = lines[0].split(/\s*:\s*/)[0].trim();
+      return cmdlet ? `${cmdlet}: ${msg}` : msg;
+    }
+
+    return lines.find(l => l.trim())?.trim() ?? clean;
+  }
+
   private exec(command: string, timeoutMs = EXEC_TIMEOUT_MS): Promise<string> {
     return new Promise((resolve, reject) => {
       exec(command, { timeout: timeoutMs, maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
         if (err) {
-          reject(new Error(stderr?.trim() || err.message));
+          reject(new Error(BcContainerService.cleanPsError(stderr) || err.message));
           return;
         }
         resolve(stdout);

--- a/src/docker/bcContainerService.ts
+++ b/src/docker/bcContainerService.ts
@@ -468,14 +468,27 @@ export class BcContainerService {
       { location: vscode.ProgressLocation.Notification, title: "Backing up database…" },
       async (progress) => {
         progress.report({ message: "Creating backup inside container…" });
-        const { serverInstance, dbName } = await this.getContainerInfo(containerName);
+        const { dbName } = await this.getContainerInfo(containerName);
+
+        // Detect SQL Server Express (EngineEdition = 4) and create temp dir in parallel.
+        // Express does not support BACKUP WITH COMPRESSION; all other editions do.
+        const [editionRaw] = await Promise.all([
+          this.execInContainer(
+            containerName,
+            `(Invoke-Sqlcmd -Query "SELECT SERVERPROPERTY('EngineEdition') AS e").e`,
+            15_000,
+          ).catch(() => ""),
+          this.execInContainer(
+            containerName,
+            `New-Item -Path 'C:\\temp' -ItemType Directory -Force -ErrorAction SilentlyContinue | Out-Null`,
+            15_000,
+          ).catch(() => {}),
+        ]);
+        const bakOptions = editionRaw.trim() === "4" ? "WITH FORMAT" : "WITH FORMAT, COMPRESSION";
 
         await this.execInContainer(
           containerName,
-          [
-            `New-Item -Path 'C:\\temp' -ItemType Directory -Force -ErrorAction SilentlyContinue | Out-Null;`,
-            `Invoke-Sqlcmd -Query "BACKUP DATABASE [${dbName}] TO DISK='${containerBakPath}' WITH FORMAT, COMPRESSION"`,
-          ].join(" "),
+          `Invoke-Sqlcmd -Query "BACKUP DATABASE [${dbName}] TO DISK='${containerBakPath}' ${bakOptions}"`,
           600_000, // 10 min timeout for large DBs
         );
 

--- a/src/docker/bcContainerService.ts
+++ b/src/docker/bcContainerService.ts
@@ -180,20 +180,21 @@ export class BcContainerService {
       });
 
       const readStream = fs.createReadStream(hostPath, { highWaterMark: FILE_TRANSFER_CHUNK });
-      let pending = Buffer.alloc(0);
+      let pending: Buffer<ArrayBuffer> = Buffer.alloc(0);
 
-      readStream.on("data", (chunk: Buffer) => {
-        const buf = pending.length ? Buffer.concat([pending, chunk]) : chunk;
+      readStream.on("data", (chunk: string | Buffer<ArrayBufferLike>) => {
+        const raw: Buffer<ArrayBuffer> = Buffer.isBuffer(chunk) ? Buffer.from(chunk) : Buffer.from(chunk as string);
+        const buf = pending.length ? Buffer.concat([pending, raw]) : raw;
         const usable = buf.length - (buf.length % 3);
         if (usable > 0) {
           const canContinue = proc.stdin.write(buf.slice(0, usable).toString("base64") + "\n");
-          pending = buf.slice(usable);
+          pending = buf.slice(usable) as Buffer<ArrayBuffer>;
           if (!canContinue) {
             readStream.pause();
             proc.stdin.once("drain", () => readStream.resume());
           }
         } else {
-          pending = buf;
+          pending = buf as Buffer<ArrayBuffer>;
         }
       });
 


### PR DESCRIPTION
Closes #6

## What changed

Hyper-V containers block direct filesystem access. Any \docker cp\ call on a running Hyper-V container fails:

> filesystem operations against a running Hyper-V container are not supported

This affects license upload, app publish, database backup, database restore, and AL compilation.

## How it works now

All file transfers go through a single long-lived \docker exec\ process that streams data over stdin/stdout rather than spawning a new process per chunk.

**Host to container (upload)**
The host reads the file in 48 KB slices, encodes each slice as a base64 line, and writes it to the process stdin. The container reads line by line, decodes, and appends raw bytes to the target file. Backpressure is handled: if stdin signals full, the read stream pauses until the buffer drains.

**Container to host (download)**
The container reads the file in 48 KB slices and writes base64 directly to stdout using \[Console]::Write()\, bypassing the PowerShell pipeline to avoid extra whitespace. The host decodes quanta of 4 base64 characters as they arrive and writes raw bytes to a write stream. If the write stream signals full, stdout is paused until it drains.

**Chunk size**
48 KB (49,152 bytes = 16,384 x 3). Every full chunk is divisible by 3 raw bytes, so no padding characters appear mid-stream. Only the final chunk may carry \=\ padding.

**Timeout**
Each transfer has a 30-minute hard timeout. The process is killed and any partial file on the host is deleted if the timeout fires.

## What this means in practice

A 500 MB backup previously opened roughly 10,000 \docker exec\ processes at ~400 ms each. That is about 67 minutes. The same backup now streams through one process and completes in seconds.

## Other changes in this branch

- SQL Server Express edition detected automatically before backup. Compression is omitted when Express is detected, preventing the \BACKUP DATABASE WITH COMPRESSION is not supported on Express\ error.
- PowerShell ANSI escape sequences stripped from error messages before they appear in VS Code notifications.

## Call sites

| Feature | Before | After |
|---------|--------|-------|
| Upload license | \docker cp\ | Streaming write |
| Publish app | \docker cp\ | Streaming write |
| Backup database | \docker cp\ | Streaming read |
| Restore database | \docker cp\ | Streaming write |
| Compile app (project dir) | \docker cp\ | Streaming write |
| Compile app (output .app) | \docker cp\ | Streaming read |

## Tests

380 tests pass. Replaced 6 exec-based chunk tests with 8 spawn-based streaming tests. Updated 3 backup edition-detection tests to use the new stream helpers.