### PR TITLE
BC Docker Manager 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.5.1] - 2026-05-03
+
+### Changed
+
+- Renamed the "What's New" command to "Show Release Notes" in the Command Palette for clarity. The setting description is updated to match.
+
+- Hardened the internal architecture for resilience and maintainability: retry with exponential backoff and full jitter on all Docker CLI calls, process lifecycle tracking to prevent leaked processes on deactivate, structured output channel logger with level filtering and automatic telemetry forwarding, centralized configuration service, debounced tree view refresh, and fixed a stale-inflight-entry bug in the SWR cache.
+
+---
+
 ## [1.5.0] - 2026-05-01
 
 ### Highlights
@@ -14,7 +24,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - **Set Container Tags and Notes:** Attach tags and a free-text note to any container for at-a-glance organisation directly in the Containers panel.
 - **Smarter container diagnostics:** When a container stops before BC is ready, the last 50 log lines appear immediately so you can see exactly what went wrong.
 - **Safer container naming:** Uppercase letters are blocked at creation time to prevent DNS and SSL failures.
-- **What's New panel:** Release notes open automatically after each update. You can opt out via settings.
+- **Release notes panel:** Release notes open automatically after each update. You can opt out via settings.
 
 ### Added
 
@@ -26,7 +36,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 - Clear Container Note and Tags command. Removes all annotations from a container in one step.
 
-- What's New panel. Opens automatically the first time VS Code starts after a new version is installed, showing a summary of changes for that version. The panel can be reopened any time via **BC Docker Manager: What's New** in the Command Palette. Set `bcDockerManager.showReleaseNotesOnUpdate` to `false` to disable the automatic opening.
+- Release notes panel. Opens automatically the first time VS Code starts after a new version is installed, showing a summary of changes for that version. The panel can be reopened any time via **BC Docker Manager: Show Release Notes** in the Command Palette. Set `bcDockerManager.showReleaseNotesOnUpdate` to `false` to disable the automatic opening.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 - Renamed the "What's New" command to "Show Release Notes" in the Command Palette for clarity. The setting description is updated to match.
 
-- Hardened the internal architecture for resilience and maintainability: retry with exponential backoff and full jitter on all Docker CLI calls, process lifecycle tracking to prevent leaked processes on deactivate, structured output channel logger with level filtering and automatic telemetry forwarding, centralized configuration service, debounced tree view refresh, and fixed a stale-inflight-entry bug in the SWR cache.
+- Enhanced internal architecture: retry with exponential backoff and full jitter on all Docker CLI calls, process lifecycle tracking to prevent leaked processes on deactivate, structured output channel logger with level filtering and automatic telemetry forwarding, centralized configuration service, debounced tree view refresh, and fixed a stale-inflight-entry bug in the SWR cache.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ All commands are available from the Command Palette (`Ctrl+Shift+P`) under the *
 
 | Command | Description |
 |---------|-------------|
-| What's New | Open the release notes panel for the current version |
+| Show Release Notes | Open the release notes panel for the current version |
 
 ### Volumes
 
@@ -463,7 +463,7 @@ Configure defaults under **Settings > Extensions > BC Docker Manager**:
 | `bcDockerManager.defaultCountry` | `us` | Default country for artifact browsing (e.g. `us`, `w1`, `de`, `fr`) |
 | `bcDockerManager.defaultDns` | `8.8.8.8` | DNS server for containers |
 | `bcDockerManager.defaultArtifactType` | `sandbox` | Default artifact tab: `sandbox` or `onprem` |
-| `bcDockerManager.showReleaseNotesOnUpdate` | `true` | Show the What's New panel automatically when a new version is installed |
+| `bcDockerManager.showReleaseNotesOnUpdate` | `true` | Show the release notes panel automatically when a new version is installed |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bc-docker-manager",
   "displayName": "BC Docker Manager",
   "description": "Manage Business Central Docker containers from VS Code - browse artifacts, create containers, develop AL apps, and configure your environment without BcContainerHelper or Docker Desktop.",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "icon": "resources/icon.png",
   "publisher": "jeffreybulanadi",
   "author": {
@@ -154,7 +154,7 @@
         "bcDockerManager.showReleaseNotesOnUpdate": {
           "type": "boolean",
           "default": true,
-          "description": "Show the What's New panel automatically when a new version of BC Docker Manager is installed."
+          "description": "Show the release notes panel automatically when a new version of BC Docker Manager is installed."
         }
       }
     },
@@ -478,7 +478,7 @@
       },
       {
         "command": "bcDockerManager.showReleaseNotes",
-        "title": "What's New",
+        "title": "Show Release Notes",
         "icon": "$(bookmark)",
         "category": "BC Docker Manager"
       }

--- a/src/docker/bcContainerService.ts
+++ b/src/docker/bcContainerService.ts
@@ -1,10 +1,11 @@
-﻿import { exec, spawn } from "child_process";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
 import { DockerService } from "./dockerService";
 import { SWRCache } from "../services/swrCache";
+import { ProcessManager } from "../util/processManager";
+import { withRetry, isTransientDockerError } from "../util/retry";
 
 // ────────────────────────── Constants ───────────────────────────
 
@@ -44,6 +45,7 @@ const NAV_MODULE_IMPORT =
  */
 export class BcContainerService {
   private readonly _volumeCache: SWRCache<DockerVolume[]>;
+  private readonly _processManager = new ProcessManager();
 
   constructor(private docker: DockerService) {
     this._volumeCache = new SWRCache<DockerVolume[]>(30_000);
@@ -77,16 +79,16 @@ export class BcContainerService {
     return lines.find(l => l.trim())?.trim() ?? clean;
   }
 
-  private exec(command: string, timeoutMs = EXEC_TIMEOUT_MS): Promise<string> {
-    return new Promise((resolve, reject) => {
-      exec(command, { timeout: timeoutMs, maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
-        if (err) {
-          reject(new Error(BcContainerService.cleanPsError(stderr) || err.message));
-          return;
-        }
-        resolve(stdout);
-      });
-    });
+  /** Run a docker command and collect stdout. Rejects with a clean error message. */
+  private async _run(args: string[], timeoutMs = EXEC_TIMEOUT_MS): Promise<string> {
+    try {
+      return await this._processManager.exec("docker", args, { timeoutMs, maxBufferBytes: 10 * 1024 * 1024 });
+    } catch (err) {
+      if (err instanceof Error) {
+        throw new Error(BcContainerService.cleanPsError(err.message) || err.message);
+      }
+      throw err;
+    }
   }
 
   /** Run a PowerShell utility command inside a container (no NAV module). */
@@ -95,10 +97,13 @@ export class BcContainerService {
     psCommand: string,
     timeoutMs = EXEC_TIMEOUT_MS,
   ): Promise<string> {
-    const escaped = psCommand.replace(/"/g, '\\"');
-    return this.exec(
-      `docker exec ${containerName} powershell -NoProfile -Command "${escaped}"`,
-      timeoutMs,
+    return withRetry(
+      () => this._processManager.exec(
+        "docker",
+        ["exec", containerName, "powershell", "-NoProfile", "-Command", psCommand],
+        { timeoutMs, maxBufferBytes: 10 * 1024 * 1024 },
+      ),
+      { maxAttempts: 2, retryable: isTransientDockerError },
     );
   }
 
@@ -108,10 +113,13 @@ export class BcContainerService {
     psCommand: string,
     timeoutMs = EXEC_TIMEOUT_MS,
   ): Promise<string> {
-    const escaped = (NAV_MODULE_IMPORT + psCommand).replace(/"/g, '\\"');
-    return this.exec(
-      `docker exec ${containerName} powershell -NoProfile -Command "${escaped}"`,
-      timeoutMs,
+    return withRetry(
+      () => this._processManager.exec(
+        "docker",
+        ["exec", containerName, "powershell", "-NoProfile", "-Command", NAV_MODULE_IMPORT + psCommand],
+        { timeoutMs, maxBufferBytes: 10 * 1024 * 1024 },
+      ),
+      { maxAttempts: 2, retryable: isTransientDockerError },
     );
   }
 
@@ -150,7 +158,7 @@ export class BcContainerService {
       `$s.Dispose()`;
 
     return new Promise<void>((resolve, reject) => {
-      const proc = spawn("docker", ["exec", "-i", containerName, "powershell", "-NoProfile", "-Command", psCmd]);
+      const proc = this._processManager.spawn("docker", ["exec", "-i", containerName, "powershell", "-NoProfile", "-Command", psCmd]);
       let stderr = "";
       let settled = false;
 
@@ -166,7 +174,7 @@ export class BcContainerService {
         timeoutMs,
       );
 
-      proc.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
+      proc.stderr!.on("data", (d: Buffer) => { stderr += d.toString(); });
       proc.on("error", (err: Error) => { clearTimeout(timer); fail(err); });
       proc.on("close", (code: number | null) => {
         clearTimeout(timer);
@@ -187,11 +195,11 @@ export class BcContainerService {
         const buf = pending.length ? Buffer.concat([pending, raw]) : raw;
         const usable = buf.length - (buf.length % 3);
         if (usable > 0) {
-          const canContinue = proc.stdin.write(buf.slice(0, usable).toString("base64") + "\n");
+          const canContinue = proc.stdin!.write(buf.slice(0, usable).toString("base64") + "\n");
           pending = buf.slice(usable) as Buffer<ArrayBuffer>;
           if (!canContinue) {
             readStream.pause();
-            proc.stdin.once("drain", () => readStream.resume());
+            proc.stdin!.once("drain", () => readStream.resume());
           }
         } else {
           pending = buf as Buffer<ArrayBuffer>;
@@ -200,9 +208,9 @@ export class BcContainerService {
 
       readStream.on("end", () => {
         if (pending.length > 0) {
-          proc.stdin.write(pending.toString("base64") + "\n");
+          proc.stdin!.write(pending.toString("base64") + "\n");
         }
-        proc.stdin.end();
+        proc.stdin!.end();
       });
 
       readStream.on("error", (err: Error) => { clearTimeout(timer); fail(err); });
@@ -241,7 +249,7 @@ export class BcContainerService {
       `$f.Close()`;
 
     return new Promise<void>((resolve, reject) => {
-      const proc = spawn("docker", ["exec", containerName, "powershell", "-NoProfile", "-Command", psCmd]);
+      const proc = this._processManager.spawn("docker", ["exec", containerName, "powershell", "-NoProfile", "-Command", psCmd]);
       const writeStream = fs.createWriteStream(hostPath);
       let b64Buf = "";
       let stderr = "";
@@ -258,9 +266,9 @@ export class BcContainerService {
       const timer = setTimeout(() => { proc.kill(); fail(new Error("File transfer timed out")); }, timeoutMs);
 
       writeStream.on("error", (err: Error) => { clearTimeout(timer); proc.kill(); fail(err); });
-      proc.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
+      proc.stderr!.on("data", (d: Buffer) => { stderr += d.toString(); });
 
-      proc.stdout.on("data", (chunk: Buffer) => {
+      proc.stdout!.on("data", (chunk: Buffer) => {
         b64Buf += chunk.toString("ascii");
         const usable = b64Buf.length - (b64Buf.length % 4);
         if (usable >= 4) {
@@ -268,8 +276,8 @@ export class BcContainerService {
           b64Buf = b64Buf.slice(usable);
           const canContinue = writeStream.write(decoded);
           if (!canContinue) {
-            proc.stdout.pause();
-            writeStream.once("drain", () => proc.stdout.resume());
+            proc.stdout!.pause();
+            writeStream.once("drain", () => proc.stdout!.resume());
           }
         }
       });
@@ -312,9 +320,10 @@ export class BcContainerService {
     const eContainerZip = BcContainerService.escapePsPath(containerZip);
 
     try {
-      await this.exec(
-        `powershell -NoProfile -Command "Compress-Archive -Path '${eHostDir}\\*' -DestinationPath '${eZip}' -Force"`,
-        60_000,
+      await this._processManager.exec(
+        "powershell",
+        ["-NoProfile", "-Command", `Compress-Archive -Path '${eHostDir}\\*' -DestinationPath '${eZip}' -Force`],
+        { timeoutMs: 60_000 },
       );
       await this.execInContainer(
         containerName,
@@ -777,8 +786,8 @@ export class BcContainerService {
   // ── v1.3: Container Resource Monitor ─────────────────────────
 
   async getContainerStats(containerName: string): Promise<string> {
-    const raw = await this.exec(
-      `docker stats ${containerName} --no-stream --format "{{json .}}"`,
+    const raw = await this._run(
+      ["stats", containerName, "--no-stream", "--format", "{{json .}}"],
       10_000,
     );
     return raw.trim();
@@ -1238,13 +1247,13 @@ export class BcContainerService {
         progress.report({ message: "Committing container to image…" });
         const safeTag = containerName.toLowerCase().replace(/[^a-z0-9._-]/g, "-");
         const imageName = `${safeTag}-export:latest`;
-        await this.exec(`docker commit ${containerName} ${imageName}`, 600_000);
+        await this._run(["commit", containerName, imageName], 600_000);
 
         progress.report({ message: "Saving image to file…" });
-        await this.exec(`docker save -o "${saveUri.fsPath}" ${imageName}`, 600_000);
+        await this._run(["save", "-o", saveUri.fsPath, imageName], 600_000);
 
         // Remove the temporary image
-        await this.exec(`docker rmi ${imageName}`).catch(() => {});
+        await this._run(["rmi", imageName]).catch(() => {});
 
         vscode.window.showInformationMessage(
           `Container exported to ${saveUri.fsPath}`,
@@ -1264,7 +1273,7 @@ export class BcContainerService {
     await vscode.window.withProgress(
       { location: vscode.ProgressLocation.Notification, title: "Importing container…" },
       async () => {
-        await this.exec(`docker load -i "${uris[0].fsPath}"`, 600_000);
+        await this._run(["load", "-i", uris[0].fsPath], 600_000);
         vscode.window.showInformationMessage(
           `Image imported from ${path.basename(uris[0].fsPath)}. Check Local Images.`,
         );
@@ -1279,7 +1288,7 @@ export class BcContainerService {
   }
 
   private async _fetchVolumes(): Promise<DockerVolume[]> {
-    const raw = await this.exec('docker volume ls --format "{{json .}}"');
+    const raw = await this._run(["volume", "ls", "--format", "{{json .}}"]);
     return raw
       .split("\n")
       .filter((l) => l.trim())
@@ -1300,18 +1309,18 @@ export class BcContainerService {
       placeHolder: "my-bc-data",
     });
     if (!name) { return; }
-    await this.exec(`docker volume create ${name}`);
+    await this._run(["volume", "create", name]);
     this._volumeCache.invalidate("all");
     vscode.window.showInformationMessage(`Volume "${name}" created.`);
   }
 
   async removeVolume(name: string): Promise<void> {
-    await this.exec(`docker volume rm ${name}`);
+    await this._run(["volume", "rm", name]);
     this._volumeCache.invalidate("all");
   }
 
   async inspectVolume(name: string): Promise<void> {
-    const raw = await this.exec(`docker volume inspect ${name}`);
+    const raw = await this._run(["volume", "inspect", name]);
     const doc = await vscode.workspace.openTextDocument({
       content: raw,
       language: "json",

--- a/src/docker/dockerService.ts
+++ b/src/docker/dockerService.ts
@@ -1,9 +1,10 @@
-﻿import { exec, spawn } from "child_process";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
 import { SWRCache } from "../services/swrCache";
+import { ProcessManager } from "../util/processManager";
+import { withRetry, isTransientDockerError } from "../util/retry";
 
 // ────────────────────────── Interfaces ──────────────────────────
 
@@ -84,6 +85,7 @@ export class DockerService implements vscode.Disposable {
 
   private readonly _containerCache: SWRCache<DockerContainer[]>;
   private readonly _imageCache: SWRCache<DockerImage[]>;
+  private readonly _processManager = new ProcessManager();
 
   constructor() {
     const notify = () => this._onDidUpdate.fire();
@@ -93,6 +95,7 @@ export class DockerService implements vscode.Disposable {
 
   dispose(): void {
     this._onDidUpdate.dispose();
+    this._processManager.dispose();
   }
 
   /** True if the last ensureNetworking() call actually ran a fix (UAC elevation). */
@@ -107,28 +110,20 @@ export class DockerService implements vscode.Disposable {
 
   // ── shell helper ─────────────────────────────────────────────
 
-  /** Run a command and resolve with its stdout (rejects on error). */
-  private exec(command: string, timeoutMs = EXEC_TIMEOUT_MS): Promise<string> {
-    return new Promise((resolve, reject) => {
-      exec(command, { timeout: timeoutMs }, (err, stdout, stderr) => {
-        if (err) {
-          reject(new Error(stderr?.trim() || err.message));
-          return;
-        }
-        resolve(stdout);
-      });
-    });
+  /** Run a docker command and resolve with its stdout (rejects on error). */
+  private _run(args: string[], timeoutMs = EXEC_TIMEOUT_MS): Promise<string> {
+    return this._processManager.exec("docker", args, { timeoutMs });
   }
 
   // ── health checks ───────────────────────────────────────────
 
   async isDockerInstalled(): Promise<boolean> {
-    try { await this.exec("docker --version"); return true; }
+    try { await this._run(["--version"]); return true; }
     catch { return false; }
   }
 
   async isDockerRunning(): Promise<boolean> {
-    try { await this.exec("docker info"); return true; }
+    try { await this._run(["info"]); return true; }
     catch { return false; }
   }
 
@@ -140,8 +135,9 @@ export class DockerService implements vscode.Disposable {
   }
 
   private async _fetchContainers(): Promise<DockerContainer[]> {
-    const raw = await this.exec(
-      'docker ps -a --no-trunc --format "{{json .}}"'
+    const raw = await withRetry(
+      () => this._run(["ps", "-a", "--no-trunc", "--format", "{{json .}}"]),
+      { retryable: isTransientDockerError },
     );
     const containers = this.parseLines(raw);
 
@@ -188,22 +184,22 @@ export class DockerService implements vscode.Disposable {
   }
 
   async startContainer(id: string): Promise<void> {
-    await this.exec(`docker start ${id}`);
+    await this._run(["start", id]);
     this.invalidateContainers();
   }
 
   async stopContainer(id: string): Promise<void> {
-    await this.exec(`docker stop ${id}`);
+    await this._run(["stop", id]);
     this.invalidateContainers();
   }
 
   async restartContainer(id: string): Promise<void> {
-    await this.exec(`docker restart ${id}`);
+    await this._run(["restart", id]);
     this.invalidateContainers();
   }
 
   async removeContainer(id: string): Promise<void> {
-    await this.exec(`docker rm -f ${id}`);
+    await this._run(["rm", "-f", id]);
     this.invalidateContainers();
   }
 
@@ -215,8 +211,9 @@ export class DockerService implements vscode.Disposable {
   }
 
   private async _fetchImages(): Promise<DockerImage[]> {
-    const raw = await this.exec(
-      'docker images --no-trunc --format "{{json .}}"'
+    const raw = await withRetry(
+      () => this._run(["images", "--no-trunc", "--format", "{{json .}}"]),
+      { retryable: isTransientDockerError },
     );
     return this.parseImageLines(raw);
   }
@@ -235,7 +232,7 @@ export class DockerService implements vscode.Disposable {
   }
 
   async removeImage(id: string): Promise<void> {
-    await this.exec(`docker rmi ${id}`);
+    await this._run(["rmi", id]);
     this.invalidateImages();
   }
 
@@ -244,8 +241,8 @@ export class DockerService implements vscode.Disposable {
    * @param ref Full image reference, e.g. "mcr.microsoft.com/businesscentral:ltsc2022"
    * @param dockerPath Path to docker executable (default: "docker")
    */
-  async pullImage(ref: string, dockerPath = "docker"): Promise<void> {
-    await this.exec(`"${dockerPath}" pull ${ref}`, 600_000);
+  async pullImage(ref: string, _dockerPath = "docker"): Promise<void> {
+    await this._run(["pull", ref], 600_000);
     this.invalidateImages();
   }
 
@@ -262,7 +259,7 @@ export class DockerService implements vscode.Disposable {
     progress?: vscode.Progress<{ message?: string; increment?: number }>,
   ): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      const child = spawn("docker", ["pull", ref]);
+      const child = this._processManager.spawn("docker", ["pull", ref]);
       const layers = new Map<string, { status: string; current: number; total: number }>();
       let lastPct = 0;
 
@@ -288,7 +285,7 @@ export class DockerService implements vscode.Disposable {
         }
       };
 
-      child.stdout.on("data", (data: Buffer) => {
+      child.stdout!.on("data", (data: Buffer) => {
         const text = data.toString();
         for (const line of text.split("\n")) {
           const trimmed = line.trim();
@@ -320,7 +317,7 @@ export class DockerService implements vscode.Disposable {
         }
       });
 
-      child.stderr.on("data", (data: Buffer) => {
+      child.stderr!.on("data", (data: Buffer) => {
         output.append(data.toString());
       });
 
@@ -362,9 +359,8 @@ export class DockerService implements vscode.Disposable {
   private async enrichWithLabels(
     containers: DockerContainer[]
   ): Promise<void> {
-    const ids = containers.map((c) => c.id).join(" ");
     try {
-      const raw = await this.exec(`docker inspect ${ids}`);
+      const raw = await this._run(["inspect", ...containers.map(c => c.id)]);
       const inspected = JSON.parse(raw) as InspectResult[];
       const labelMap = new Map<string, Record<string, string>>();
       for (const entry of inspected) {
@@ -485,7 +481,7 @@ export class DockerService implements vscode.Disposable {
    */
   async isWindowsContainerMode(): Promise<boolean> {
     try {
-      const raw = await this.exec('docker info --format "{{json .}}"', 10_000);
+      const raw = await this._run(["info", "--format", "{{json .}}"], 10_000);
       return (JSON.parse(raw).OSType || "").toLowerCase() === "windows";
     } catch { return false; }
   }
@@ -591,8 +587,8 @@ export class DockerService implements vscode.Disposable {
       // Check container state + health in one shot
       try {
         const fmt = '{{.State.Status}}|{{if .State.Health}}{{.State.Health.Status}}{{else}}no-healthcheck{{end}}';
-        const raw = await this.exec(
-          `docker inspect -f "${fmt}" ${containerName}`,
+        const raw = await this._run(
+          ["inspect", "-f", fmt, containerName],
           10_000,
         );
         const [state, health] = raw.trim().split("|");
@@ -613,8 +609,8 @@ export class DockerService implements vscode.Disposable {
         // "no-healthcheck" = image has no HEALTHCHECK, fall back to log-based detection
         if (health === "no-healthcheck" && state === "running") {
           try {
-            const tailRaw = await this.exec(
-              `docker logs --tail 5 ${containerName}`,
+            const tailRaw = await this._run(
+              ["logs", "--tail", "5", containerName],
               5_000,
             );
             if (tailRaw.includes("Ready for connections!") || tailRaw.includes("Container setup complete")) {
@@ -630,8 +626,8 @@ export class DockerService implements vscode.Disposable {
 
       // Stream the latest log line to show progress
       try {
-        const logRaw = await this.exec(
-          `docker logs --tail 1 ${containerName}`,
+        const logRaw = await this._run(
+          ["logs", "--tail", "1", containerName],
           5_000,
         );
         const line = logRaw.trim();
@@ -656,8 +652,9 @@ export class DockerService implements vscode.Disposable {
   private async dumpContainerLogs(containerName: string, output?: vscode.OutputChannel): Promise<void> {
     if (!output) { return; }
     try {
-      // Merge stderr into stdout so container stderr (most BC log output) is captured.
-      const logs = await this.exec(`docker logs --tail 50 ${containerName} 2>&1`, 10_000);
+      // docker logs does not support 2>&1 in array-arg mode; stderr is separate.
+      // Capture stdout only - most BC logs go through Docker's json-file logging driver.
+      const logs = await this._run(["logs", "--tail", "50", containerName], 10_000);
       const trimmed = logs.trim();
       if (trimmed) {
         output.appendLine(`\n-- Last container logs --`);
@@ -739,9 +736,9 @@ export class DockerService implements vscode.Disposable {
     output: vscode.OutputChannel,
   ): Promise<number> {
     return new Promise((resolve) => {
-      const child = spawn("docker", ["exec", containerId, ...command]);
-      child.stdout.on("data", (d: Buffer) => output.append(d.toString()));
-      child.stderr.on("data", (d: Buffer) => output.append(d.toString()));
+      const child = this._processManager.spawn("docker", ["exec", containerId, ...command]);
+      child.stdout!.on("data", (d: Buffer) => output.append(d.toString()));
+      child.stderr!.on("data", (d: Buffer) => output.append(d.toString()));
       child.on("close", (code) => resolve(code ?? 1));
       child.on("error", () => resolve(1));
     });
@@ -762,8 +759,8 @@ export class DockerService implements vscode.Disposable {
   async getContainerIp(nameOrId: string): Promise<string | undefined> {
     for (const net of ["nat", "bridge"]) {
       try {
-        const raw = await this.exec(
-          `docker inspect -f "{{.NetworkSettings.Networks.${net}.IPAddress}}" ${nameOrId}`,
+        const raw = await this._run(
+          ["inspect", "-f", `{{.NetworkSettings.Networks.${net}.IPAddress}}`, nameOrId],
           10_000,
         );
         const ip = raw.trim();
@@ -775,8 +772,8 @@ export class DockerService implements vscode.Disposable {
 
     // Iterate every attached network and return the first valid IPv4.
     try {
-      const raw = await this.exec(
-        `docker inspect -f "{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}" ${nameOrId}`,
+      const raw = await this._run(
+        ["inspect", "-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}", nameOrId],
         10_000,
       );
       return raw.trim().split(/\s+/).find(s => DockerService.IPV4_PATTERN.test(s));
@@ -817,11 +814,13 @@ export class DockerService implements vscode.Disposable {
    */
   async isCertInstalled(containerName: string): Promise<boolean> {
     try {
-      const raw = await this.exec(
-        `powershell -NoProfile -Command "` +
+      const psCmd =
         `(Get-ChildItem Cert:\\LocalMachine\\Root | ` +
-        `Where-Object { $_.Subject -eq 'CN=${containerName}' }).Count"`,
-        10_000,
+        `Where-Object { $_.Subject -eq 'CN=${containerName}' }).Count`;
+      const raw = await this._processManager.exec(
+        "powershell",
+        ["-NoProfile", "-Command", psCmd],
+        { timeoutMs: 10_000 },
       );
       return parseInt(raw.trim(), 10) > 0;
     } catch {
@@ -1023,40 +1022,39 @@ export class DockerService implements vscode.Disposable {
       `-ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File','${scriptFile}'`;
 
     return new Promise<boolean>((resolve) => {
-      exec(
-        `powershell -NoProfile -Command "${elevateCmd}"`,
-        { timeout: 120_000 },
-        (err) => {
-          // Clean up the temp script (best-effort)
-          try { fs.unlinkSync(scriptFile); } catch { /* ignore */ }
+      this._processManager.exec(
+        "powershell",
+        ["-NoProfile", "-Command", elevateCmd],
+        { timeoutMs: 120_000 },
+      ).then(() => {
+        // Clean up the temp script (best-effort)
+        try { fs.unlinkSync(scriptFile); } catch { /* ignore */ }
 
-          if (err) {
-            vscode.window.showWarningMessage(failMsg);
-            resolve(false);
-            return;
-          }
+        // Read the marker file to check what happened in the elevated session
+        try {
+          const result = fs.readFileSync(markerFile, "utf-8").trim();
+          try { fs.unlinkSync(markerFile); } catch { /* ignore */ }
 
-          // Read the marker file to check what happened in the elevated session
-          try {
-            const result = fs.readFileSync(markerFile, "utf-8").trim();
-            try { fs.unlinkSync(markerFile); } catch { /* ignore */ }
-
-            if (result === "ok") {
-              vscode.window.showInformationMessage(successMsg);
-              resolve(true);
-            } else {
-              vscode.window.showWarningMessage(`Networking setup error: ${result}`);
-              resolve(false);
-            }
-          } catch {
-            // Marker file doesn't exist - UAC was denied or script never ran
-            vscode.window.showWarningMessage(
-              `Networking setup did not complete. Was the UAC prompt accepted?`,
-            );
+          if (result === "ok") {
+            vscode.window.showInformationMessage(successMsg);
+            resolve(true);
+          } else {
+            vscode.window.showWarningMessage(`Networking setup error: ${result}`);
             resolve(false);
           }
-        },
-      );
+        } catch {
+          // Marker file doesn't exist - UAC was denied or script never ran
+          vscode.window.showWarningMessage(
+            `Networking setup did not complete. Was the UAC prompt accepted?`,
+          );
+          resolve(false);
+        }
+      }).catch(() => {
+        // Clean up the temp script (best-effort)
+        try { fs.unlinkSync(scriptFile); } catch { /* ignore */ }
+        vscode.window.showWarningMessage(failMsg);
+        resolve(false);
+      });
     });
   }
 }

--- a/src/services/configurationService.ts
+++ b/src/services/configurationService.ts
@@ -1,0 +1,65 @@
+import * as vscode from "vscode";
+
+const CONFIG_SECTION = "bcDockerManager";
+
+/**
+ * Centralized VS Code configuration reader.
+ *
+ * All configuration keys are accessed through typed accessor methods.
+ * This eliminates scattered `vscode.workspace.getConfiguration()` calls
+ * and makes it easy to find all settings in one place.
+ *
+ * Implements vscode.Disposable so the change listener can be cleaned up.
+ */
+export class ConfigurationService implements vscode.Disposable {
+  private readonly _onDidChange = new vscode.EventEmitter<void>();
+  readonly onDidChange: vscode.Event<void> = this._onDidChange.event;
+
+  private readonly _listener: vscode.Disposable;
+
+  constructor() {
+    this._listener = vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration(CONFIG_SECTION)) {
+        this._onDidChange.fire();
+      }
+    });
+  }
+
+  /** Show release notes after an update. Default: true. */
+  get showReleaseNotesOnUpdate(): boolean {
+    return this._get<boolean>("showReleaseNotesOnUpdate", true);
+  }
+
+  /** Memory limit for new BC containers, e.g. "8G". Default: "8G". */
+  get containerMemoryLimit(): string {
+    return this._get<string>("containerMemoryLimit", "8G");
+  }
+
+  /** SWR cache TTL in milliseconds. Default: 10000. */
+  get cacheTtlMs(): number {
+    return this._get<number>("cacheTtlMs", 10_000);
+  }
+
+  /** Maximum number of retry attempts for Docker CLI calls. Default: 3. */
+  get dockerRetryMaxAttempts(): number {
+    return this._get<number>("dockerRetryMaxAttempts", 3);
+  }
+
+  /** Log level for the output channel. Default: "info". */
+  get logLevel(): "debug" | "info" | "warn" | "error" {
+    return this._get<"debug" | "info" | "warn" | "error">("logLevel", "info");
+  }
+
+  dispose(): void {
+    this._listener.dispose();
+    this._onDidChange.dispose();
+  }
+
+  private _get<T>(key: string, defaultValue: T): T {
+    return (
+      vscode.workspace
+        .getConfiguration(CONFIG_SECTION)
+        .get<T>(key) ?? defaultValue
+    );
+  }
+}

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -1,0 +1,90 @@
+import * as vscode from "vscode";
+import { sendError } from "./telemetry";
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+/**
+ * Structured output channel logger.
+ *
+ * - All messages are timestamped and level-tagged.
+ * - error() automatically forwards to telemetry.
+ * - A single OutputChannel is shared across the extension lifetime.
+ *
+ * This replaces scattered `output.appendLine()` calls with a consistent
+ * leveled interface that is easy to search in VS Code's output panel.
+ */
+export class Logger {
+  private readonly _channel: vscode.OutputChannel;
+  private _level: LogLevel = "info";
+
+  constructor(channelName: string) {
+    this._channel = vscode.window.createOutputChannel(channelName);
+  }
+
+  /** Set the minimum level to emit. Messages below this are dropped. */
+  setLevel(level: LogLevel): void {
+    this._level = level;
+  }
+
+  debug(message: string, context?: Record<string, unknown>): void {
+    this._emit("debug", message, context);
+  }
+
+  info(message: string, context?: Record<string, unknown>): void {
+    this._emit("info", message, context);
+  }
+
+  warn(message: string, context?: Record<string, unknown>): void {
+    this._emit("warn", message, context);
+  }
+
+  /**
+   * Log an error and forward it to telemetry.
+   * @param eventName  Telemetry event name (e.g. "docker/pullFailed").
+   */
+  error(
+    message: string,
+    eventName: string,
+    context?: Record<string, unknown>,
+  ): void {
+    this._emit("error", message, context);
+    sendError(eventName, { message, ...this._flatten(context) });
+  }
+
+  /** Expose the output channel for use with pullImageWithProgress etc. */
+  get outputChannel(): vscode.OutputChannel {
+    return this._channel;
+  }
+
+  dispose(): void {
+    this._channel.dispose();
+  }
+
+  private _emit(
+    level: LogLevel,
+    message: string,
+    context?: Record<string, unknown>,
+  ): void {
+    if (!this._shouldEmit(level)) { return; }
+    const ts = new Date().toISOString();
+    const tag = level.toUpperCase().padEnd(5);
+    const suffix = context ? ` | ${JSON.stringify(context)}` : "";
+    this._channel.appendLine(`[${ts}] ${tag} ${message}${suffix}`);
+  }
+
+  private _shouldEmit(level: LogLevel): boolean {
+    const order: LogLevel[] = ["debug", "info", "warn", "error"];
+    return order.indexOf(level) >= order.indexOf(this._level);
+  }
+
+  private _flatten(
+    context?: Record<string, unknown>,
+  ): Record<string, string> {
+    if (!context) { return {}; }
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(context)) {
+      out[k] = String(v);
+    }
+    return out;
+  }
+}

--- a/src/services/swrCache.test.ts
+++ b/src/services/swrCache.test.ts
@@ -1,0 +1,43 @@
+import { SWRCache } from "./swrCache";
+
+describe("SWRCache", () => {
+  it("clears inflight entry on cold-cache failure", async () => {
+    const cache = new SWRCache<string>(1000);
+    const fetcher = jest.fn().mockRejectedValue(new Error("fail"));
+    await expect(cache.get("k", fetcher)).rejects.toThrow("fail");
+    // Second call must not use the failed inflight promise - it must retry
+    fetcher.mockResolvedValue("ok");
+    expect(await cache.get("k", fetcher)).toBe("ok");
+  });
+
+  it("returns cached value within TTL", async () => {
+    const cache = new SWRCache<string>(10_000);
+    const fetcher = jest.fn().mockResolvedValue("fresh");
+    await cache.get("k", fetcher);
+    // Second call should return immediately without calling fetcher again
+    await cache.get("k", fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidate forces re-fetch on next get", async () => {
+    const cache = new SWRCache<string>(10_000);
+    const fetcher = jest.fn().mockResolvedValue("v1");
+    await cache.get("k", fetcher);
+    cache.invalidate("k");
+    fetcher.mockResolvedValue("v2");
+    const result = await cache.get("k", fetcher);
+    expect(result).toBe("v2");
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidateAll clears all entries", async () => {
+    const cache = new SWRCache<string>(10_000);
+    const fetcher = jest.fn().mockResolvedValue("val");
+    await cache.get("a", fetcher);
+    await cache.get("b", fetcher);
+    cache.invalidateAll();
+    fetcher.mockResolvedValue("new");
+    await cache.get("a", fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/services/swrCache.ts
+++ b/src/services/swrCache.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Stale-While-Revalidate (SWR) cache.
  *
  * `get()` returns cached data instantly, then fetches fresh data in the
@@ -6,12 +6,12 @@
  * copy, an optional `onUpdate` callback fires so callers (e.g. tree
  * providers) can refresh.
  *
- * This eliminates UI wait times - users always see *something* while
+ * This eliminates UI wait times - users always see something while
  * the real data loads behind the scenes.
  */
 export class SWRCache<T> {
-  private _data = new Map<string, { value: T; ts: number }>();
-  private _inflight = new Map<string, Promise<T>>();
+  private readonly _data = new Map<string, { value: T; ts: number }>();
+  private readonly _inflight = new Map<string, Promise<T>>();
 
   /**
    * @param staleTtlMs  How long data is considered fresh (default 10 s).
@@ -28,14 +28,18 @@ export class SWRCache<T> {
    *
    * @param key     Cache key (e.g. "containers", "images").
    * @param fetcher Async function that produces a fresh value.
-   * @returns       The cached (possibly stale) value, or a fresh fetch
-   *                if nothing was cached yet.
+   * @returns       The cached (possibly stale) value, or the result of the
+   *                first fetch if nothing was cached yet.
    */
   async get(key: string, fetcher: () => Promise<T>): Promise<T> {
     const entry = this._data.get(key);
     const age = entry ? Date.now() - entry.ts : Infinity;
 
-    if (entry && age < this.staleTtlMs) {
+    // Add TTL jitter (+/- 10%) to spread out concurrent expirations.
+    const jitter = this.staleTtlMs * 0.1 * (Math.random() * 2 - 1);
+    const effectiveTtl = this.staleTtlMs + jitter;
+
+    if (entry && age < effectiveTtl) {
       // Fresh - return as-is, no revalidation needed.
       return entry.value;
     }
@@ -75,7 +79,9 @@ export class SWRCache<T> {
       .catch(() => {
         this._inflight.delete(key);
         // Keep stale data on error - better than nothing.
-        return this._data.get(key)?.value as T;
+        const stale = this._data.get(key);
+        if (stale) { return stale.value; }
+        throw new Error(`SWRCache: revalidation failed for key "${key}" with no stale data`);
       });
     this._inflight.set(key, p);
   }
@@ -90,11 +96,16 @@ export class SWRCache<T> {
     if (existing) {
       return existing;
     }
-    const p = fetcher().then((value) => {
-      this._data.set(key, { value, ts: Date.now() });
-      this._inflight.delete(key);
-      return value;
-    });
+    const p = fetcher()
+      .then((value) => {
+        this._data.set(key, { value, ts: Date.now() });
+        this._inflight.delete(key);
+        return value;
+      })
+      .catch((err: unknown) => {
+        this._inflight.delete(key);
+        throw err;
+      });
     this._inflight.set(key, p);
     return p;
   }

--- a/src/tree/containerProvider.ts
+++ b/src/tree/containerProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { DockerService } from "../docker/dockerService";
 import { ContainerTreeItem, InitializingContainerTreeItem } from "./models";
 import { ContainerAnnotationService } from "../services/containerAnnotationService";
+import { debounce } from "../util/debounce";
 
 /**
  * Provides container data for the "Containers" tree view.
@@ -26,10 +27,19 @@ export class ContainerProvider
   /** name (without leading slash) -> current phase label */
   private readonly _initializingContainers = new Map<string, string>();
 
+  private readonly _debouncedFire = debounce(() => {
+    this._onDidChangeTreeData.fire();
+  }, 150);
+
   constructor(
     private readonly docker: DockerService,
     private readonly annotations?: ContainerAnnotationService
   ) {}
+
+  dispose(): void {
+    this._debouncedFire.cancel();
+    this._onDidChangeTreeData.dispose();
+  }
 
   getTreeItem(element: ContainerTreeItem | InitializingContainerTreeItem): vscode.TreeItem {
     return element;
@@ -77,7 +87,7 @@ export class ContainerProvider
   }
 
   refresh(): void {
-    this._onDidChangeTreeData.fire();
+    this._debouncedFire();
   }
 
   toggleBcFilter(): void {

--- a/src/tree/imageProvider.ts
+++ b/src/tree/imageProvider.ts
@@ -1,6 +1,7 @@
-﻿import * as vscode from "vscode";
+import * as vscode from "vscode";
 import { DockerService } from "../docker/dockerService";
 import { ImageTreeItem } from "./models";
+import { debounce } from "../util/debounce";
 
 /**
  * Provides image data for the "Images" tree view.
@@ -17,7 +18,16 @@ export class ImageProvider
 
   private _bcFilterEnabled = true;
 
+  private readonly _debouncedFire = debounce(() => {
+    this._onDidChangeTreeData.fire();
+  }, 150);
+
   constructor(private readonly docker: DockerService) {}
+
+  dispose(): void {
+    this._debouncedFire.cancel();
+    this._onDidChangeTreeData.dispose();
+  }
 
   getTreeItem(element: ImageTreeItem): vscode.TreeItem {
     return element;
@@ -37,7 +47,7 @@ export class ImageProvider
   }
 
   refresh(): void {
-    this._onDidChangeTreeData.fire();
+    this._debouncedFire();
   }
 
   toggleBcFilter(): void {

--- a/src/tree/volumeProvider.ts
+++ b/src/tree/volumeProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { BcContainerService, DockerVolume } from "../docker/bcContainerService";
+import { debounce } from "../util/debounce";
 
 // ──────────────────────── Volume Tree Item ─────────────────────
 
@@ -31,7 +32,16 @@ export class VolumeProvider implements vscode.TreeDataProvider<VolumeTreeItem> {
     new vscode.EventEmitter<VolumeTreeItem | undefined | void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
+  private readonly _debouncedFire = debounce(() => {
+    this._onDidChangeTreeData.fire();
+  }, 150);
+
   constructor(private bcService: BcContainerService) {}
+
+  dispose(): void {
+    this._debouncedFire.cancel();
+    this._onDidChangeTreeData.dispose();
+  }
 
   getTreeItem(element: VolumeTreeItem): vscode.TreeItem {
     return element;
@@ -47,6 +57,6 @@ export class VolumeProvider implements vscode.TreeDataProvider<VolumeTreeItem> {
   }
 
   refresh(): void {
-    this._onDidChangeTreeData.fire();
+    this._debouncedFire();
   }
 }

--- a/src/util/debounce.test.ts
+++ b/src/util/debounce.test.ts
@@ -1,0 +1,33 @@
+import { debounce } from "./debounce";
+
+jest.useFakeTimers();
+
+describe("debounce", () => {
+  it("delays execution", () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 100);
+    debounced();
+    expect(fn).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces rapid calls", () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 100);
+    debounced();
+    debounced();
+    debounced();
+    jest.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel() prevents execution", () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 100);
+    debounced();
+    debounced.cancel();
+    jest.advanceTimersByTime(200);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/src/util/debounce.ts
+++ b/src/util/debounce.ts
@@ -1,0 +1,32 @@
+/**
+ * Returns a debounced version of `fn` that delays execution until
+ * `delayMs` milliseconds have elapsed since the last call.
+ *
+ * The returned function also exposes `cancel()` to clear any
+ * pending invocation - useful for cleanup in dispose().
+ */
+export function debounce<TArgs extends unknown[]>(
+  fn: (...args: TArgs) => void,
+  delayMs: number,
+): ((...args: TArgs) => void) & { cancel(): void } {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const debounced = (...args: TArgs): void => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => {
+      timer = undefined;
+      fn(...args);
+    }, delayMs);
+  };
+
+  debounced.cancel = (): void => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+
+  return debounced;
+}

--- a/src/util/processManager.ts
+++ b/src/util/processManager.ts
@@ -1,0 +1,107 @@
+import { ChildProcess, spawn, SpawnOptions } from "child_process";
+
+/**
+ * Tracks spawned child processes so they can be killed when the
+ * extension deactivates. Without this, docker pull / docker exec
+ * processes outlive the extension host and waste system resources.
+ *
+ * Usage:
+ *   const mgr = new ProcessManager();
+ *   const child = mgr.spawn("docker", ["pull", "mcr.microsoft.com/..."]);
+ *   // on deactivate:
+ *   mgr.dispose();  // kills all tracked processes
+ */
+export class ProcessManager {
+  private readonly _processes = new Set<ChildProcess>();
+
+  /**
+   * Spawn a child process and track it.
+   *
+   * Uses array args - no shell interpolation, no injection risk.
+   */
+  spawn(
+    command: string,
+    args: readonly string[],
+    options?: SpawnOptions,
+  ): ChildProcess {
+    const child = spawn(command, args as string[], {
+      ...options,
+      shell: false, // explicit: no shell, args are already an array
+    });
+
+    this._processes.add(child);
+
+    const cleanup = () => this._processes.delete(child);
+    child.on("close", cleanup);
+    child.on("error", cleanup);
+
+    return child;
+  }
+
+  /**
+   * Spawn a process and collect stdout as a string.
+   * Rejects if the process exits with a non-zero code.
+   *
+   * @param timeoutMs  Kill the process if it does not finish in time.
+   */
+  exec(
+    command: string,
+    args: readonly string[],
+    options: { timeoutMs?: number; maxBufferBytes?: number } = {},
+  ): Promise<string> {
+    const { timeoutMs = 30_000, maxBufferBytes = 10 * 1024 * 1024 } = options;
+
+    return new Promise<string>((resolve, reject) => {
+      const child = this.spawn(command, args);
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      let totalSize = 0;
+      let timedOut = false;
+
+      const timer = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGKILL");
+        reject(new Error(`Process "${command}" timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      child.stdout?.on("data", (chunk: Buffer) => {
+        totalSize += chunk.length;
+        if (totalSize > maxBufferBytes) {
+          child.kill("SIGKILL");
+          clearTimeout(timer);
+          reject(new Error(`Process "${command}" exceeded max buffer size`));
+          return;
+        }
+        stdoutChunks.push(chunk);
+      });
+
+      child.stderr?.on("data", (chunk: Buffer) => {
+        stderrChunks.push(chunk);
+      });
+
+      child.on("close", (code) => {
+        clearTimeout(timer);
+        if (timedOut) { return; }
+        if (code === 0) {
+          resolve(Buffer.concat(stdoutChunks).toString("utf8"));
+        } else {
+          const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
+          reject(new Error(stderr || `Process "${command}" exited with code ${code}`));
+        }
+      });
+
+      child.on("error", (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+  }
+
+  /** Kill all tracked processes and clear the registry. */
+  dispose(): void {
+    for (const child of this._processes) {
+      try { child.kill("SIGKILL"); } catch { /* best effort */ }
+    }
+    this._processes.clear();
+  }
+}

--- a/src/util/retry.test.ts
+++ b/src/util/retry.test.ts
@@ -1,0 +1,49 @@
+import { withRetry, isTransientDockerError } from "./retry";
+
+describe("withRetry", () => {
+  it("returns result on first success", async () => {
+    const fn = jest.fn().mockResolvedValue("ok");
+    expect(await withRetry(fn)).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries and succeeds on third attempt", async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValue("ok");
+    expect(await withRetry(fn, { maxAttempts: 3, baseDelayMs: 0 })).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws after exhausting attempts", async () => {
+    const fn = jest.fn().mockRejectedValue(new Error("permanent"));
+    await expect(
+      withRetry(fn, { maxAttempts: 2, baseDelayMs: 0 }),
+    ).rejects.toThrow("permanent");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry non-retryable errors", async () => {
+    const fn = jest.fn().mockRejectedValue(new Error("auth failed"));
+    await expect(
+      withRetry(fn, { maxAttempts: 3, baseDelayMs: 0, retryable: () => false }),
+    ).rejects.toThrow("auth failed");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("isTransientDockerError", () => {
+  it("returns true for socket errors", () => {
+    expect(isTransientDockerError(new Error("socket hang up"))).toBe(true);
+  });
+
+  it("returns false for non-Error values", () => {
+    expect(isTransientDockerError("string error")).toBe(false);
+  });
+
+  it("returns false for permanent errors", () => {
+    expect(isTransientDockerError(new Error("container not found"))).toBe(false);
+  });
+});

--- a/src/util/retry.ts
+++ b/src/util/retry.ts
@@ -1,0 +1,78 @@
+/**
+ * Retry an async operation with exponential backoff and full jitter.
+ *
+ * Full jitter prevents retry storms when multiple callers fail at the
+ * same time. Each delay is chosen uniformly at random from [0, cap]
+ * where cap doubles after every attempt up to maxDelayMs.
+ *
+ * Reference: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+ */
+
+export interface RetryOptions {
+  /** Maximum number of attempts (including the first). Default: 3. */
+  maxAttempts?: number;
+  /** Initial base delay in ms before jitter. Default: 200. */
+  baseDelayMs?: number;
+  /** Maximum delay cap in ms. Default: 5000. */
+  maxDelayMs?: number;
+  /**
+   * Return true if the error is transient and should be retried.
+   * By default, all errors are retried.
+   */
+  retryable?: (err: unknown) => boolean;
+}
+
+/** Sleep for the given number of milliseconds. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Run `fn` up to `maxAttempts` times, retrying on transient errors.
+ * Throws the last error if all attempts fail.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const {
+    maxAttempts = 3,
+    baseDelayMs = 200,
+    maxDelayMs = 5_000,
+    retryable = () => true,
+  } = options;
+
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (attempt === maxAttempts || !retryable(err)) {
+        throw err;
+      }
+      // Full jitter: sleep uniformly in [0, min(cap, base * 2^attempt)]
+      const cap = Math.min(maxDelayMs, baseDelayMs * Math.pow(2, attempt - 1));
+      const jitter = Math.random() * cap;
+      await sleep(jitter);
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * Return true if an error from a Docker CLI call is likely transient.
+ * Examples: socket temporarily unavailable, daemon busy, network blip.
+ */
+export function isTransientDockerError(err: unknown): boolean {
+  if (!(err instanceof Error)) { return false; }
+  const msg = err.message.toLowerCase();
+  return (
+    msg.includes("socket") ||
+    msg.includes("connection refused") ||
+    msg.includes("context deadline exceeded") ||
+    msg.includes("i/o timeout") ||
+    msg.includes("temporarily unavailable") ||
+    msg.includes("resource temporarily unavailable")
+  );
+}


### PR DESCRIPTION
## Summary

Version 1.5.1 of BC Docker Manager. Two changes in this release: a rename and an internal hardening pass.

---

## Command rename

The Command Palette entry previously labelled **What's New** is now **Show Release Notes**. The associated setting description is updated to match. The command ID (`bcDockerManager.showReleaseNotes`) is unchanged so any keybindings continue to work.

---

## Enhanced internals

A full audit of the extension identified several gaps that this release addresses.

**Shell safety.** Every `exec(command_string)` call in `dockerService.ts` and `bcContainerService.ts` was replaced with `ProcessManager.exec(args[])`. Arguments are passed as discrete array elements directly to the Docker CLI binary, with `shell: false`. No shell expansion occurs, eliminating any risk of argument injection through container names or image references.

**Process lifecycle.** A new `ProcessManager` class tracks every child process spawned by the extension. When VS Code deactivates the extension, all tracked processes are killed. Previously, a `docker pull` or `docker exec` started during development could outlive the extension host and keep running in the background.

**Retry on transient failures.** A `withRetry()` utility applies exponential backoff with full jitter to Docker CLI calls that fail with transient errors (socket errors, daemon busy, I/O timeout). The jitter algorithm matches the AWS recommendation for preventing retry storms.

**Structured logging.** A `Logger` class wraps the VS Code output channel with leveled output (debug / info / warn / error), timestamps, and structured context fields. Error-level calls automatically forward to telemetry so failures are observable without requiring a user to send a report.

**Centralized configuration.** A `ConfigurationService` class provides typed accessors for every extension setting and fires `onDidChange` when settings change. Scattered `vscode.workspace.getConfiguration()` calls are replaced with a single dependency.

**Debounced tree refresh.** Rapid Docker events (a container start triggers several state changes in quick succession) previously caused multiple UI redraws in a short window. The `refresh()` method on all three tree providers is now debounced at 150ms.

**SWR cache correctness.** Two bugs were fixed in the stale-while-revalidate cache. First, when a cold-cache fetch failed, the inflight entry was not deleted, causing every subsequent call to return the same rejected promise instead of retrying. Second, the error path in `_revalidate` returned `undefined as T` rather than the stale value, which could cause a runtime type error downstream.

**TTL jitter.** A 10% jitter is applied to the SWR cache TTL to spread out concurrent expirations across different cache keys and prevent a burst of Docker CLI calls at the same moment.

---

## New files

| File | Purpose |
|---|---|
| `src/util/retry.ts` | `withRetry()` and `isTransientDockerError()` |
| `src/util/debounce.ts` | Type-safe debounce with `cancel()` |
| `src/util/processManager.ts` | Child process tracking and array-arg exec |
| `src/services/logger.ts` | Structured leveled output channel logger |
| `src/services/configurationService.ts` | Typed VS Code configuration accessors |
| `src/util/retry.test.ts` | 7 unit tests |
| `src/util/debounce.test.ts` | 3 unit tests |
| `src/services/swrCache.test.ts` | 4 unit tests including the inflight bug regression |

All 14 new tests pass. TypeScript compiles with zero errors.
