### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - "feat/**"
+      - "fix/**"
+      - "ci/**"
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    name: Build and test
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Run unit tests
+        run: npm test -- --no-coverage --ci
+
+      - name: Run unit tests with coverage
+        if: matrix.node-version == '20.x'
+        run: npm test -- --coverage --ci
+
+      - name: Upload coverage report
+        if: matrix.node-version == '20.x'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/
+          retention-days: 14


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs on every push and pull request targeting `main`.

---

## What runs

- Type check via `tsc --noEmit` to catch TypeScript errors before merge
- Unit tests on Node 20 and Node 22 in parallel so version drift is caught early
- Coverage report generated on Node 20 and uploaded as a build artifact, kept for 14 days

The workflow triggers on pushes to `main` and any branch under `feat/`, `fix/`, or `ci/`, and on all pull requests targeting `main`.

---

## How to verify

Open the Actions tab after this PR is merged. You should see a **CI** workflow run appear. All steps should pass green. The coverage artifact will be available for download from the run summary page.
