### PR TITLE
Fix tree provider refresh tests after debounce was introduced

### DIFF
--- a/src/tree/containerProvider.test.ts
+++ b/src/tree/containerProvider.test.ts
@@ -125,11 +125,15 @@ describe("ContainerProvider.toggleBcFilter", () => {
 // ─── refresh ─────────────────────────────────────────────────────
 
 describe("ContainerProvider.refresh", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
   it("fires onDidChangeTreeData event", () => {
     const mockDocker = createMockDocker();
     const provider = new ContainerProvider(mockDocker);
 
     provider.refresh();
+    jest.runAllTimers();
 
     // The EventEmitter mock from vscode-mock.ts exposes `fire` as a jest.fn()
     // Access the underlying emitter via the provider's internal field.

--- a/src/tree/imageProvider.test.ts
+++ b/src/tree/imageProvider.test.ts
@@ -107,12 +107,16 @@ describe("ImageProvider.toggleBcFilter", () => {
 // ─── refresh ─────────────────────────────────────────────────────
 
 describe("ImageProvider.refresh", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
   it("fires the onDidChangeTreeData event", () => {
     const provider = new ImageProvider(createMockDocker());
 
     // Access the internal EventEmitter to verify fire() is called
     const emitter = (provider as any)._onDidChangeTreeData;
     provider.refresh();
+    jest.runAllTimers();
 
     expect(emitter.fire).toHaveBeenCalled();
   });
@@ -202,12 +206,16 @@ describe("ImageProvider.getChildren - untagged images", () => {
 // ─── refresh fires event after toggle ────────────────────────────
 
 describe("ImageProvider - refresh fires event after toggle", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
   it("toggleBcFilter implicitly calls refresh - event emitter fires", () => {
     const provider = new ImageProvider(createMockDocker());
     const emitter = (provider as any)._onDidChangeTreeData;
 
     emitter.fire.mockClear();
     provider.toggleBcFilter();
+    jest.runAllTimers();
 
     expect(emitter.fire).toHaveBeenCalled();
   });

--- a/src/tree/volumeProvider.test.ts
+++ b/src/tree/volumeProvider.test.ts
@@ -128,11 +128,15 @@ describe("VolumeProvider.getChildren", () => {
 // ─── refresh ─────────────────────────────────────────────────────
 
 describe("VolumeProvider.refresh", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
   it("fires the onDidChangeTreeData event", () => {
     const provider = new VolumeProvider(createMockBcService());
     const emitter = (provider as any)._onDidChangeTreeData;
 
     provider.refresh();
+    jest.runAllTimers();
 
     expect(emitter.fire).toHaveBeenCalled();
   });


### PR DESCRIPTION
The refresh() method on all three tree providers was debounced at 150ms as part of the architecture hardening work. The existing tests called refresh() and immediately checked that the event emitter had fired, which no longer worked because the fire happens after the debounce delay.

The fix is to call jest.useFakeTimers() in the affected describe blocks and advance the clock with jest.runAllTimers() after calling refresh(). This lets the debounce flush synchronously in tests without slowing down the test suite.

All 45 tests in the three affected files pass locally.