### PR TITLE
Release notes: two-column layout with inline navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 [![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/jeffreybulanadi.bc-docker-manager?label=VS%20Code%20Marketplace&logo=visual-studio-code&color=0078d7)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.bc-docker-manager)
 [![Installs](https://img.shields.io/visual-studio-marketplace/i/jeffreybulanadi.bc-docker-manager?color=63ba83)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.bc-docker-manager)
+[![CI](https://github.com/jeffreybulanadi/bc-docker-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/jeffreybulanadi/bc-docker-manager/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-> A lightweight, all-in-one control center for **Business Central Docker development** inside VS Code.
-> Browse artifacts, create containers, manage your environment, and develop AL apps - **without BcContainerHelper or Docker Desktop**.
+> Manage Business Central Docker containers from inside VS Code. Browse artifacts from the Microsoft CDN, create containers, develop AL apps, and keep your environment healthy -- all without installing BcContainerHelper or Docker Desktop.
 
-> **Note:** You must run VS Code as an **Administrator** for BC Docker Manager to work properly, as it requires elevated permissions for certain operations (e.g., networking, hosts file, Docker Engine setup).
+> **Administrator required.** VS Code must be launched as Administrator. Some operations write to `C:\Windows\System32\drivers\etc\hosts`, install certificates into the Windows Trusted Root store, and interact with Windows optional features. These require elevation.
 
 <!-- SCREENSHOT: Full VS Code window showing the BC Docker Manager sidebar (all sections expanded)
      with a running container visible and the Artifacts Explorer open in the editor area.
@@ -16,26 +16,128 @@
 
 ---
 
-## Features at a Glance
+## Table of Contents
 
-| | Feature | What it does |
-|---|---------|-------------|
-| | [Artifacts Explorer](#bc-artifacts-explorer) | Browse & create containers from the Microsoft CDN |
-| | [Container Management](#container-management) | Full lifecycle: start, stop, restart, remove, export, import |
-| | [Container Annotations](#container-annotations) | Attach tags and notes to containers |
-| | [Environment Setup](#environment-setup) | One-click wizard for Hyper-V, Windows Containers & Docker Engine |
-| | [AL Development](#al-development) | Generate launch.json, compile apps, publish to containers |
-| | [Networking & SSL](#networking--ssl) | Auto-configure hosts file and install self-signed certificates |
-| | [User Management](#user-management) | Create BC users and test users inside containers |
-| | [Database Operations](#database-operations) | Backup and restore databases with a single click |
-| | [Monitoring](#monitoring) | Live container stats, logs, and event log viewer |
-| | [Profiles & Bulk Ops](#container-profiles--bulk-operations) | Save/load container configs, bulk start/stop/remove |
+- [Why BC Docker Manager](#why-bc-docker-manager)
+- [Getting Started](#getting-started)
+  - [Prerequisites](#prerequisites)
+  - [Quick Start](#quick-start)
+  - [Your First Container](#your-first-container)
+- [How It Works](#how-it-works)
+- [Features](#features)
+  - [BC Artifacts Explorer](#bc-artifacts-explorer)
+  - [Container Management](#container-management)
+  - [Container Annotations](#container-annotations)
+  - [Environment Setup](#environment-setup)
+  - [AL Development](#al-development)
+  - [Networking and SSL](#networking-and-ssl)
+  - [User Management](#user-management)
+  - [Database Operations](#database-operations)
+  - [Monitoring](#monitoring)
+  - [Container Profiles and Bulk Operations](#container-profiles-and-bulk-operations)
+  - [Images and Volumes](#images-and-volumes)
+- [Configuration Reference](#configuration-reference)
+  - [Isolation Modes](#isolation-modes)
+  - [Authentication Modes](#authentication-modes)
+- [Commands Reference](#commands-reference)
+- [Troubleshooting](#troubleshooting)
+- [Security and Permissions](#security-and-permissions)
+- [What's New](#whats-new)
+- [Contributing](#contributing)
+- [Telemetry](#telemetry)
+- [License](#license)
 
 ---
 
-## BC Artifacts Explorer
+## Why BC Docker Manager
 
-Browse every Business Central artifact on the Microsoft CDN directly from VS Code. Switch between **Sandbox** and **OnPrem** tabs, filter by country and major version, then create a container in three clicks.
+Business Central development on Windows typically requires either **BcContainerHelper** (a PowerShell module with many dependencies) or **Docker Desktop** (a paid product for most commercial teams). Both add significant overhead to a developer workstation.
+
+BC Docker Manager takes a different approach. It calls the Docker Engine directly using the `docker` CLI, without going through BcContainerHelper or Docker Desktop's management layer. You get the same results with fewer moving parts.
+
+**What you avoid:**
+- Installing and maintaining the BcContainerHelper PowerShell module
+- Paying for a Docker Desktop license for commercial use
+- Running Docker Desktop's background services and extra memory overhead
+- Writing PowerShell scripts for every routine container task
+
+**What you get instead:**
+- A VS Code sidebar that shows your containers, images, and volumes in real time
+- A CDN browser that lists every published BC artifact -- sandbox and on-premises -- with filtering and sorting
+- Container creation, networking, licensing, AL compilation, database backup, and more, all from the same panel
+- Persistent tags and notes on containers so you always know which container is which
+- Container profiles that save and restore full configurations
+
+The extension is tested against Node.js 20 and 22 on every pull request. It has no runtime dependency on PowerShell modules outside the container itself.
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+| Requirement | Minimum | Notes |
+|-------------|---------|-------|
+| Windows | Windows 10 build 1909 or Windows Server 2019 | Required for Windows Containers support |
+| VS Code | 1.85.0 | [Download](https://code.visualstudio.com) |
+| Hyper-V | Any | The extension can enable this for you. Requires a restart. |
+| Docker Engine | Any current release | The extension can install this for you. Docker Desktop is not required. |
+
+> **Windows Home users:** Hyper-V is not available on Windows Home editions. You need Windows 10 or 11 Pro, Enterprise, or Education -- or Windows Server.
+
+### Quick Start
+
+1. Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.bc-docker-manager).
+2. Close VS Code, then reopen it as **Administrator** (right-click the VS Code shortcut and choose "Run as administrator").
+3. Click the **BC Docker Manager** icon in the activity bar on the left side of VS Code.
+4. Open the **Environment** panel. Click **Setup Everything** if any items show a problem.
+5. Restart your machine if prompted. Hyper-V activation requires a restart.
+6. Reopen VS Code as Administrator after the restart.
+7. Open the **BC Artifacts** panel and click **Open BC Artifacts Explorer**.
+8. Select a country, pick a BC version, and click **Create Container**.
+
+### Your First Container
+
+The container creation wizard collects four inputs:
+
+1. **Container name** -- A short lowercase name, for example `bc25us`. The name becomes the container's DNS hostname and the CN of its SSL certificate. Uppercase letters are blocked. Underscores trigger a warning because they are not valid in DNS hostnames.
+2. **Username** -- The BC administrator account. Default: `admin`.
+3. **Password** -- The BC administrator password. BC enforces password complexity requirements.
+4. **Accept EULA** -- You must agree to the Microsoft Business Central EULA.
+
+After you confirm, the extension:
+- Runs `docker run` with your chosen isolation mode, memory limit, and authentication settings
+- Shows each initialization phase in the VS Code notification and sidebar: Downloading artifact, Installing prerequisites, Configuring SQL Server, Importing license, Installing Business Central, Ready
+- Configures networking (hosts file and SSL certificate) automatically when BC becomes healthy
+- Shows a completion notification with links to open the BC web client or generate `launch.json`
+
+If something goes wrong, the last 50 log lines appear in the output channel immediately. Common causes are listed as a hint: not enough memory, missing license, or incompatible artifact.
+
+You can cancel at any time using the **Cancel** button in the progress notification. The extension stops the health-check loop and removes the partially-created container.
+
+---
+
+## How It Works
+
+BC Docker Manager is a VS Code extension written in TypeScript. It communicates with Docker by running the `docker` CLI directly -- the same commands you would type in a terminal. There is no custom daemon, no additional service, and no PowerShell module required on the host machine.
+
+**Artifact browsing** fetches metadata from the Microsoft BC CDN (`bcartifacts.azureedge.net`) and caches it using a stale-while-revalidate (SWR) strategy. The list is shown immediately from cache while fresh data loads in the background. When the background fetch finishes and the data has changed, the view updates automatically. Cache entries expire after 10 seconds with a small random jitter to spread out concurrent requests.
+
+**Container and image data** is also served from the SWR cache. The sidebar renders in under a millisecond from cache, then refreshes silently. The cache invalidates immediately after any create, start, stop, restart, or remove operation.
+
+**File transfers** (license upload, AL app publish, database backup, database restore) use a single persistent `docker exec` process. The extension opens one long-running PowerShell session inside the container and streams data through a 48 KB sliding window, regardless of file size. An earlier design spawned a new process per 5-50 KB chunk. On a 500 MB database backup that was roughly 10,000 process starts at around 400 ms each -- hours instead of seconds.
+
+**Docker CLI calls** that may fail transiently (network blips, Docker daemon startup) are retried with exponential backoff and full jitter. The maximum retry window is bounded to prevent a thundering-herd effect when multiple commands are issued at the same time.
+
+**Logging** goes through a shared structured logger. Every message is timestamped and tagged with a severity level (debug, info, warn, error). Error-level messages are forwarded to telemetry automatically. The `BC Docker Manager` output channel is the same channel throughout the extension lifetime.
+
+---
+
+## Features
+
+### BC Artifacts Explorer
+
+Browse every Business Central artifact published to the Microsoft CDN without leaving VS Code.
 
 <!-- SCREENSHOT: The Artifacts Explorer webview with the SANDBOX tab active,
      a country selected (e.g. "us"), and the table populated with artifact rows.
@@ -43,23 +145,18 @@ Browse every Business Central artifact on the Microsoft CDN directly from VS Cod
      Save as: screenshots/artifacts-explorer.png -->
 ![Artifacts Explorer](screenshots/artifacts-explorer.png)
 
-- **Tabbed browsing** - Sandbox / OnPrem
-- **Filter** by country, major version, or free-text search
-- **Sortable columns** - click any header (version, country, date)
-- **Infinite scroll** - pagination loads automatically as you scroll
-- **One-click actions** - Copy Version, Copy URL, or **Create Container**
-- **Smart caching** - stale-while-revalidate keeps data fresh without lag
+- **Two artifact types** -- Switch between Sandbox and OnPrem using the tabs at the top.
+- **Filter by country** -- Select from the full list of country codes (`us`, `w1`, `de`, `dk`, `nl`, `fr`, `gb`, and more).
+- **Filter by major version** -- Narrow down to a specific BC major release.
+- **Free-text search** -- Type any part of a version string or date to filter inline.
+- **Sortable columns** -- Click any column header to sort by version, country, or date.
+- **Infinite scroll** -- More rows load automatically as you scroll down.
+- **One-click actions** -- Copy the version string, copy the full CDN URL, or start container creation.
+- **CDN health check** -- Run **Test BC Artifacts CDN Connection** from the command palette to verify your network can reach the CDN.
 
-### Container Creation Wizard
+#### Container Creation Wizard
 
-When you click **Create Container** on an artifact, a guided 3-step flow walks you through:
-
-1. **Container name** (defaults to `bc<major><country>`, e.g. `bc25us`)
-2. **Username** (default: `admin`)
-3. **Password**
-4. **EULA acceptance**
-
-The extension then pulls the image, runs `docker run`, waits for the health check, and automatically configures networking, all with real-time progress in the output channel.
+Click **Create Container** on any artifact row to open the guided wizard. After you complete the four inputs, the extension runs everything automatically with real-time progress shown in the notification area and the sidebar.
 
 <!-- SCREENSHOT: The VS Code notification area showing container creation progress,
      e.g. "Pulling image..." or "Container bc25us is ready!" with the output channel visible below.
@@ -68,82 +165,94 @@ The extension then pulls the image, runs `docker run`, waits for the health chec
 
 ---
 
-## Container Management
+### Container Management
 
-Everything you need to manage your BC containers lives in the sidebar. Running containers get a green icon, stopped ones get gray.
+All your containers are listed in the **Containers** sidebar panel. Running containers show a green icon; stopped containers show a gray icon. Phase descriptions and spinner icons appear while a container is initializing.
 
 <!-- SCREENSHOT: The Containers sidebar section with at least one running container and one stopped container visible.
      Show the inline action buttons (stop, restart, remove, web client, networking) on the running container.
      Save as: screenshots/containers-panel.png -->
 ![Containers Panel](screenshots/containers-panel.png)
 
-### Lifecycle
+#### Lifecycle Actions
 
-| Action | How |
-|--------|-----|
-| **Start** | Click > on a stopped container |
-| **Stop** | Click X on a running container |
-| **Restart** | Click restart or right-click > Restart |
-| **Remove** | Click trash or right-click > Remove |
-| **Export** | Right-click > Export Container (saves as `.tar`) |
-| **Import** | Toolbar > Import Container (loads a `.tar`) |
+| Action | How to trigger |
+|--------|----------------|
+| Start | Click the play button on a stopped container, or right-click > Start Container |
+| Stop | Click the stop button on a running container, or right-click > Stop Container |
+| Restart | Right-click > Restart Container |
+| Remove | Click the trash button, or right-click > Remove Container |
+| Export | Right-click > Export Container -- saves the container as a `.tar` file |
+| Import | Use the toolbar menu at the top of the Containers panel to import a `.tar` file |
 
-### Quick Access
+#### Quick Access
 
-- **Open Web Client** - launches `https://<container>/BC/` in your browser (auto-configures hosts + SSL first)
-- **Open Terminal** - interactive PowerShell session inside the container
-- **View Logs** - streams `docker logs` in real time
-- **Copy IP** - copies the container's IP address to your clipboard
-- **Show Stats** - live CPU, memory, network, and disk I/O (refreshes every 5 seconds)
+Click the inline icons on any running container:
 
-### Context Menu
+- **Open Web Client** -- opens `https://<containername>/BC/` in your browser. Networking (hosts file and SSL certificate) is configured automatically before the browser opens if it has not been set up yet.
+- **Open Terminal** -- opens an interactive PowerShell session inside the running container.
+- **View Logs** -- streams `docker logs --follow` in a VS Code terminal, showing new log lines as they arrive.
+- **Copy IP** -- copies the container's current IP address to your clipboard.
+- **Show Stats** -- opens a live statistics view that updates every 5 seconds.
 
-Right-click any container for the full action menu:
+#### Context Menu
+
+Right-click any container to see the full action menu, organized into groups:
 
 <!-- SCREENSHOT: Right-click context menu on a running container showing all menu groups:
      Container actions, Connection, BC Operations, BC Data, BC Pro Features, Advanced.
      Save as: screenshots/container-context-menu.png -->
 ![Container Context Menu](screenshots/container-context-menu.png)
 
+| Group | Actions |
+|-------|---------|
+| Container | Start, Stop, Restart, Remove, Export |
+| Connection | Open Web Client, Open Terminal, View Logs, Copy IP, Setup Networking |
+| BC Operations | Generate launch.json, Add BC User, Add Test Users, Upload License, Install Test Toolkit, Edit NST Settings |
+| BC Data | Backup Database, Restore Database |
+| Monitoring | Show Container Stats, View Event Log |
+| Annotations | Set Container Tags, Set Container Note, Clear Container Note and Tags |
+| Profiles | Save Container Profile, Load Container Profile |
+
 ---
 
-## Container Annotations
+### Container Annotations
 
-Keep track of what each container is for by attaching tags and notes directly in the sidebar. No extra files or scripts needed - annotations are stored in VS Code global state and survive container restarts and recreations.
-
-Tags and notes can be set together. Both appear in the sidebar immediately after saving.
+Attach tags and notes to any container to keep track of what each one is for. Annotations are stored in VS Code global state and survive container restarts, recreations, and VS Code restarts. They do not depend on Docker labels or container metadata.
 
 ![Container with tags and note set](screenshots/tags/set-notes-and-tags-menu.jpg)
 
-| Command | What it does |
-|---------|-------------|
-| **Set Container Tags** | Attach comma-separated tags to a container |
-| **Set Container Note** | Attach a free-text note to a container |
-| **Clear Container Note and Tags** | Remove all annotations from a container |
+#### Tags
 
-### Tags
+Right-click any container and choose **Set Container Tags**. Enter a comma-separated list of labels, for example: `client1, sandbox, v25`.
 
-Right-click any container and choose **Set Container Tags** to attach comma-separated labels.
-
-![Set Container Tags menu](screenshots/tags/set-tags.jpg)
-
-Tags appear inline in the container list as `#tag1 #tag2` so you can identify containers at a glance.
+Tags appear inline in the container list as `#client1 #sandbox #v25` so you can identify containers at a glance without hovering.
 
 ![Tags shown in container list](screenshots/tags/tags-and-notes-set.jpg)
 
-### Notes
+#### Notes
 
-Right-click any container and choose **Set Container Note** to attach a free-text note (e.g. "Client demo - do not remove" or "Restore from backup 2026-04-30").
+Right-click any container and choose **Set Container Note**. Enter any free-text note, for example: `Client demo - do not remove` or `Restore from backup 2026-04-30`.
+
+The note appears at the bottom of the container tooltip when you hover over the container name in the sidebar.
 
 ![Set Container Note menu](screenshots/tags/set-notes.jpg)
 
-The note is shown at the bottom of the container tooltip when you hover over the container.
+#### Clearing Annotations
+
+Right-click the container and choose **Clear Container Note and Tags** to remove all annotations in one step.
+
+| Command | What it does |
+|---------|-------------|
+| Set Container Tags | Attach comma-separated tags to a container |
+| Set Container Note | Attach a free-text note to a container |
+| Clear Container Note and Tags | Remove all annotations from a container |
 
 ---
 
-## Environment Setup
+### Environment Setup
 
-The **Environment** panel checks your system health and tells you exactly what's missing. Click **Setup Everything** to fix it all in one go.
+The **Environment** panel checks your system before you start and tells you exactly what is missing. You do not need to run any manual setup commands.
 
 <!-- SCREENSHOT: The Environment sidebar section expanded, showing health check items.
      Ideally show a mix of statuses: green for items that pass, red or yellow for items that need attention.
@@ -151,108 +260,132 @@ The **Environment** panel checks your system health and tells you exactly what's
      Save as: screenshots/environment-panel.png -->
 ![Environment Panel](screenshots/environment-panel.png)
 
-**Health checks** (polled every 15 seconds):
+**Health checks run every 15 seconds:**
 
 | Check | What it verifies |
 |-------|-----------------|
-| Windows Features | Hyper-V & Windows Containers are enabled |
-| Docker Engine | Docker is installed and the daemon is running |
+| Windows Features | Hyper-V and Windows Containers are both enabled |
+| Docker Engine | The Docker service is installed and running |
 
 **One-click fixes:**
-- **Enable Hyper-V & Windows Containers** - runs `Enable-WindowsOptionalFeature` (requires reboot)
-- **Install Docker Engine** - downloads the standalone engine from `download.docker.com` (no Docker Desktop needed)
-- **Start Docker Engine** - starts the Docker Windows service if it's stopped
+
+| Button | What it does |
+|--------|-------------|
+| Setup Everything | Runs all fixes in the correct order in a single step |
+| Enable Hyper-V and Windows Containers | Runs `Enable-WindowsOptionalFeature -FeatureName Hyper-V, Containers` -- requires a restart |
+| Install Docker Engine | Downloads the standalone Docker Engine from `download.docker.com` and installs it as a Windows service. Docker Desktop is not required. |
+| Start Docker Engine | Starts the `docker` Windows service if it is installed but stopped |
+
+> After **Enable Hyper-V and Windows Containers** runs, restart your machine. Reopen VS Code as Administrator after the restart. The Environment panel will then show green.
 
 ---
 
-## AL Development
+### AL Development
 
-### launch.json Generation
+BC Docker Manager works alongside the [AL Language extension](https://marketplace.visualstudio.com/items?itemName=ms-dynamics-smb.al) to speed up AL development. You do not need `alc.exe` installed on your host machine -- the extension uses the copy inside the container.
 
-Connect the [AL Language extension](https://marketplace.visualstudio.com/items?itemName=ms-dynamics-smb.al) to your container instantly:
+#### Generate launch.json
+
+The `launch.json` file connects the AL Language extension to a running BC container. BC Docker Manager generates this file for you:
 
 | Command | What it does |
 |---------|-------------|
-| **Generate AL Launch Configuration** | Writes `.vscode/launch.json` to your workspace |
-| **Preview launch.json in New Tab** | Opens the config in a read-only editor tab |
-| **Copy launch.json to Clipboard** | Copies the JSON for manual pasting |
+| Generate AL Launch Configuration | Writes `.vscode/launch.json` to your workspace root |
+| Preview launch.json in New Tab | Opens the generated config in a read-only editor tab for review |
+| Copy launch.json to Clipboard | Copies the JSON to your clipboard for manual pasting |
 
-### Compile AL App
+Right-click a running container and choose **Generate AL Launch Configuration**. The file is written to the workspace that is currently open in VS Code. If no workspace is open, you will be asked to select a folder.
 
-Compile your AL project **inside the container** using `alc.exe` - no local AL compiler needed:
+#### Compile AL App
 
-1. Right-click a container > **Compile AL App in Container**
-2. Select your workspace folder
-3. The compiled `output.app` is copied back to your workspace root
+Compile your AL project using `alc.exe` inside the container:
 
-### Publish AL App
+1. Right-click a running container and choose **Compile AL App in Container**.
+2. Select your AL workspace folder.
+3. The extension copies your source files into the container, runs `alc.exe`, and copies the compiled `output.app` back to your workspace root.
 
-Deploy your `.app` file directly:
+No AL compiler installation is required on your machine. The container already includes the correct version of `alc.exe` for the BC release it is running.
 
-1. Right-click a container > **Publish AL App to Container**
-2. Select your `.app` file
-3. The extension handles Publish > Sync > Install automatically
+#### Publish AL App
+
+Deploy a compiled `.app` file directly to a container:
+
+1. Right-click a running container and choose **Publish AL App to Container**.
+2. Select your `.app` file.
+3. The extension runs Publish, Sync, and Install in sequence automatically.
 
 ---
 
-## Networking & SSL
+### Networking and SSL
 
-BC containers use self-signed certificates and custom hostnames. This extension handles both:
+BC containers use custom hostnames and self-signed SSL certificates. Browsers reject self-signed certificates by default, and the container hostname does not resolve until it is added to your hosts file. The extension handles both.
 
 | Command | What it does |
 |---------|-------------|
-| **Setup Networking** | Updates hosts file + installs SSL cert in one step |
-| **Update Hosts File** | Maps container hostname > IP in `C:\Windows\System32\drivers\etc\hosts` |
-| **Install SSL Certificate** | Extracts the container's cert and adds it to Windows Trusted Root |
+| Setup Networking | Updates the hosts file and installs the SSL certificate in one step |
+| Update Hosts File | Adds or updates the container hostname-to-IP mapping in `C:\Windows\System32\drivers\etc\hosts` |
+| Install SSL Certificate | Extracts the container's certificate and adds it to the Windows Trusted Root Certification Authorities store |
 
-> **Tip:** When you click **Open Web Client**, networking is configured automatically if it hasn't been already.
+**Automatic setup:** When you click **Open Web Client**, the extension checks whether networking has already been configured for that container. If not, it runs **Setup Networking** before opening the browser.
+
+**After a container restart:** Container IP addresses are assigned by Docker on each start. If you restart a container, its IP may change. Run **Update Hosts File** or **Setup Networking** to refresh the mapping.
+
+**IP detection:** The extension probes the `nat` network (Windows containers) and the `bridge` network (Linux containers), validates the result as a well-formed IPv4 address, then falls back to a range-based probe if both networks return nothing. This prevents Docker daemon warning strings from being treated as IP addresses.
 
 ---
 
-## User Management
+### User Management
+
+Create BC users inside a running container without opening the web client or writing PowerShell.
 
 | Command | What it does |
 |---------|-------------|
-| **Add BC User** | Create a user with a custom name, password, and permission set |
-| **Add Test Users** | Creates 3 standard test users in one click |
+| Add BC User | Create a single user with a custom name, password, and permission set |
+| Add Test Users | Create three standard test users with a single click |
 
-**Test users created:**
+**Standard test users created by Add Test Users:**
 
-| User | Permission Set | Password |
-|------|---------------|----------|
+| Username | Permission Set | Password |
+|----------|---------------|----------|
 | ESSENTIAL | SUPER | P@ssw0rd |
 | PREMIUM | SUPER | P@ssw0rd |
 | TEAMMEMBER | D365 TEAM MEMBER | P@ssw0rd |
 
 ---
 
-## Database Operations
+### Database Operations
 
-All file transfers run through a single streaming process, so backup and restore are fast even on large databases and work without issue on Hyper-V containers.
-
-| Command | What it does |
-|---------|-------------|
-| **Backup Database** | Creates a `.bak` file via SQL Server. Express edition is detected automatically and compression is skipped when needed. |
-| **Restore Database** | Restores from a `.bak` file (stops the service tier, restores, restarts). |
-
----
-
-## Monitoring
+Backup and restore run through a single persistent streaming connection to the container. There is no temporary file staging on the host; data flows directly through the `docker exec` channel.
 
 | Command | What it does |
 |---------|-------------|
-| **Show Container Stats** | Live CPU, memory, network I/O, and block I/O (refreshes every 5 s) |
-| **View Container Logs** | Streams `docker logs --follow` in a terminal |
-| **View Event Log** | Retrieves Windows Event Log entries (MicrosoftDynamicsNavServer, MSSQL) |
-| **Edit NST Settings** | View and edit NavServerTier configuration with optional service restart |
+| Backup Database | Creates a `.bak` file inside the container using SQL Server's `BACKUP DATABASE` command, then copies it to a path you choose on your machine |
+| Restore Database | Copies a `.bak` file from your machine into the container, stops the BC service tier, restores the database, and restarts the service tier |
+
+**SQL Server Express detection:** Before each backup, the extension checks the SQL Server edition. If Express is detected, it omits the `COMPRESSION` option. SQL Server Express does not support backup compression; including it causes the command to fail with an error.
+
+**Hyper-V containers:** All file transfers go through one long-lived `docker exec` process with a 48 KB sliding window. A 500 MB backup that previously took hours now completes in seconds.
 
 ---
 
-## Container Profiles & Bulk Operations
+### Monitoring
 
-### Profiles
+| Command | What it does |
+|---------|-------------|
+| Show Container Stats | Opens a live panel showing CPU, memory, network I/O, and block I/O. Updates every 5 seconds. |
+| View Container Logs | Opens a terminal and streams `docker logs --follow` in real time |
+| View Event Log | Retrieves recent Windows Event Log entries from the MicrosoftDynamicsNavServer and MSSQL sources inside the container |
+| Edit NST Settings | Opens the NavServerTier configuration file for the container's BC service tier. You can edit values and optionally restart the service to apply changes. |
 
-Save your container configuration (memory, isolation, auth, DNS, country, license path) and reapply it later. All four commands are under the **...** menu in the Containers panel header.
+**Container exit diagnostics:** If a container stops before BC finishes initializing, the last 50 log lines appear in the output channel immediately. Common causes are listed as a hint: not enough memory, missing license, or incompatible artifact. Networking setup is skipped in this case to avoid misleading error messages.
+
+---
+
+### Container Profiles and Bulk Operations
+
+#### Profiles
+
+A profile saves a full container configuration (memory limit, isolation mode, authentication, DNS, country, and license path) to VS Code user settings under a name you choose. You can recall it later to reproduce the same container on a different machine or after a clean install.
 
 <!-- SCREENSHOT: Containers panel ... menu open showing Save, Load, Edit, Delete Container Profile.
      Save as: screenshots/profiles/profile-menus.jpg -->
@@ -260,12 +393,14 @@ Save your container configuration (memory, isolation, auth, DNS, country, licens
 
 | Command | What it does |
 |---------|-------------|
-| **Save Container Profile** | Saves current VS Code settings to a named profile |
-| **Load Container Profile** | Applies a saved profile, overwriting your VS Code settings immediately |
-| **Edit Container Profile** | Opens a saved profile with every field pre-filled so you only change what you need |
-| **Delete Container Profile** | Removes a saved profile |
+| Save Container Profile | Saves your current BC Docker Manager settings to a named profile |
+| Load Container Profile | Applies a saved profile, writing all values to your VS Code user settings immediately |
+| Edit Container Profile | Loads a saved profile into the step-by-step wizard with every field pre-filled |
+| Delete Container Profile | Removes a saved profile |
 
-Loading a profile writes memory limit, isolation, auth, DNS, and country straight to your VS Code user settings. The next container you create picks them up automatically.
+When you load a profile, your VS Code user settings are updated immediately. The next container you create picks up those values automatically. Country is only written if the profile includes one, to avoid clearing an existing country preference unintentionally.
+
+When you edit a profile, each field is pre-filled with the saved value. Isolation and authentication modes appear as a pick list with the current profile value highlighted. You only change what you need.
 
 <!-- SCREENSHOT: Load Container Profile quick pick showing profile name and details.
      Save as: screenshots/profiles/load-profile.jpg -->
@@ -275,62 +410,80 @@ Loading a profile writes memory limit, isolation, auth, DNS, and country straigh
      Save as: screenshots/profiles/profile-overwrites-user-settings-on-the-fly.jpg -->
 ![Settings updated after loading profile](screenshots/profiles/profile-overwrites-user-settings-on-the-fly.jpg)
 
-### Bulk Operations
+#### Bulk Operations
 
 | Command | What it does |
 |---------|-------------|
-| **Start All Stopped Containers** | Starts every stopped container in parallel |
-| **Stop All Running Containers** | Stops every running container in parallel |
-| **Remove All Stopped Containers** | Removes every stopped container in parallel |
+| Start All Stopped Containers | Starts every stopped container in parallel |
+| Stop All Running Containers | Stops every running container in parallel |
+| Remove All Stopped Containers | Removes every stopped container in parallel |
+
+All bulk operations run in parallel. They do not wait for one container to finish before starting the next.
 
 ---
 
-## Images & Volumes
+### Images and Volumes
 
-### Local Images
+#### Local Images
 
 <!-- SCREENSHOT: The Local Images sidebar section showing one or more BC images.
      The filter toggle icon should be visible in the toolbar.
      Save as: screenshots/images-panel.png -->
 ![Images Panel](screenshots/images-panel.png)
 
-- View all local Docker images (toggle **BC Filter** to show only Business Central images)
-- **Pre-Pull BC Image** - download `mcr.microsoft.com/businesscentral:ltsc2022` ahead of time
-- **Remove Image** - clean up unused images
+The **Local Images** panel lists all Docker images on your machine. Use the **Toggle BC Filter** button in the toolbar to show only Business Central images (those from `mcr.microsoft.com/businesscentral`).
 
-### Volumes
+| Command | What it does |
+|---------|-------------|
+| Pre-Pull BC Image | Downloads `mcr.microsoft.com/businesscentral:ltsc2022` in the background. Run this while you have a good connection to avoid waiting during container creation. |
+| Remove Image | Removes a local Docker image |
 
-- **Create Volume** - `docker volume create` with a custom name
-- **Inspect Volume** - view driver and mountpoint details
-- **Remove Volume** - delete unused volumes
+#### Volumes
 
----
+The **Volumes** panel lists all Docker volumes on your machine.
 
-## Getting Started
-
-### Prerequisites
-
-| Requirement | Notes |
-|-------------|-------|
-| **Windows 10/11** or **Windows Server 2019+** | Required for Windows Containers |
-| **Hyper-V** | The extension can enable this for you |
-| **Docker Engine** | Standalone Windows service (Docker Desktop is optional) |
-
-### Quick Start
-
-1. **Install** the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.bc-docker-manager)
-2. **Open** the **BC Docker Manager** sidebar (look for the icon in the activity bar)
-3. **Check** the **Environment** panel - click **Setup Everything** if anything is red
-4. **Browse** the **BC Artifacts Explorer** - pick a version, country, and click **Create Container**
-5. **Right-click** your new container for actions: web client, terminal, launch.json, and more
-
-<!-- SCREENSHOT (optional): Annotated "getting started" image showing the activity bar icon
-     with an arrow, the sidebar panels, and the artifacts explorer.
-     Save as: screenshots/getting-started.png -->
+| Command | What it does |
+|---------|-------------|
+| Create Volume | Creates a new Docker volume with a name you provide |
+| Inspect Volume | Shows the driver and mountpoint for a volume |
+| Remove Volume | Removes a Docker volume |
 
 ---
 
-## Commands
+## Configuration Reference
+
+Open **Settings > Extensions > BC Docker Manager** to configure defaults. All settings affect new containers; they do not change containers that already exist.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `bcDockerManager.defaultMemory` | string | `8G` | Memory limit for new containers. Accepts a number followed by a unit: `512M`, `4G`, `16G`. BC requires at least 4 GB to start. 8 GB is recommended for development. |
+| `bcDockerManager.defaultIsolation` | string | `hyperv` | Isolation mode for new containers. See [Isolation Modes](#isolation-modes). |
+| `bcDockerManager.defaultAuth` | string | `UserPassword` | Authentication type for new containers. See [Authentication Modes](#authentication-modes). |
+| `bcDockerManager.defaultCountry` | string | `us` | Country code used when the Artifacts Explorer opens. Common values: `us`, `w1`, `de`, `dk`, `nl`, `fr`, `gb`. |
+| `bcDockerManager.defaultDns` | string | `8.8.8.8` | DNS server for new containers. Use your corporate DNS if containers need to reach internal resources. |
+| `bcDockerManager.defaultArtifactType` | string | `sandbox` | Default artifact type when the Artifacts Explorer opens: `sandbox` or `onprem`. |
+| `bcDockerManager.showReleaseNotesOnUpdate` | boolean | `true` | When `true`, the release notes panel opens automatically the first time VS Code starts after a new version is installed. Set to `false` to disable. |
+
+### Isolation Modes
+
+| Mode | Description | When to use |
+|------|-------------|-------------|
+| `hyperv` | Each container runs inside a dedicated Hyper-V virtual machine with its own isolated kernel. | Use on Windows 10 or 11. Process isolation is not supported on client OS versions. Also use when security isolation between containers matters. |
+| `process` | Container processes share the host OS kernel directly. No Hyper-V VM is created. | Use on Windows Server only. Requires the host OS build to exactly match the container image OS build. Starts faster and uses less memory than Hyper-V. |
+
+> **On Windows 10 or 11, always use `hyperv`.** Process isolation requires Windows Server and an exact OS build match between the host and the container image.
+
+### Authentication Modes
+
+| Mode | Description | When to use |
+|------|-------------|-------------|
+| `UserPassword` | BC manages usernames and passwords independently of Windows. Users authenticate with a BC-specific username and password. | Use for most development scenarios. Simple to set up. Works on any machine without domain configuration. |
+| `NavUserPassword` | NAV-style authentication using a BC username and a password hash stored in the NAV user table. | Use when connecting to older NAV or BC versions that require NavUserPassword, or when following scripts that specify this mode. |
+| `Windows` | BC accepts the Windows identity of the currently logged-in user. No BC-specific password is required. | Use when the container is joined to a domain and you want single sign-on from Windows. Requires additional domain configuration. |
+
+---
+
+## Commands Reference
 
 All commands are available from the Command Palette (`Ctrl+Shift+P`) under the **BC Docker Manager** prefix.
 
@@ -341,22 +494,23 @@ All commands are available from the Command Palette (`Ctrl+Shift+P`) under the *
 <details>
 <summary><b>Full command reference (click to expand)</b></summary>
 
-### Environment & Setup
+### Environment and Setup
 
 | Command | Description |
 |---------|-------------|
 | Refresh | Refresh all containers, images, and volumes |
-| Setup Everything | One-click environment setup (Hyper-V + Docker) |
-| Enable Hyper-V & Windows Containers | Enable required Windows features |
-| Install Docker Engine | Download and install the standalone engine |
+| Setup Everything | One-click environment setup (Hyper-V and Docker) |
+| Enable Hyper-V and Windows Containers | Enable required Windows features. Requires a restart. |
+| Install Docker Engine | Download and install the standalone Docker Engine |
 | Start Docker Engine | Start the Docker Windows service |
+| Refresh Environment Status | Re-run all environment health checks immediately |
 
 ### Artifacts
 
 | Command | Description |
 |---------|-------------|
-| Open BC Artifacts Explorer | Browse BC artifacts from the Microsoft CDN |
-| Test BC Artifacts CDN Connection | Verify CDN reachability |
+| Open BC Artifacts Explorer | Open the CDN browser |
+| Test BC Artifacts CDN Connection | Verify that the CDN is reachable from your machine |
 
 ### Container Lifecycle
 
@@ -366,56 +520,56 @@ All commands are available from the Command Palette (`Ctrl+Shift+P`) under the *
 | Stop Container | Stop a running container |
 | Restart Container | Restart a running container |
 | Remove Container | Delete a container |
-| Export Container | Save container as a `.tar` image |
-| Import Container | Load a `.tar` image file |
-| Start All Stopped Containers | Bulk start |
-| Stop All Running Containers | Bulk stop |
-| Remove All Stopped Containers | Bulk remove |
-| Toggle BC Filter | Show all or only BC containers and images |
+| Export Container | Save a container as a `.tar` image file |
+| Import Container | Load a container from a `.tar` file |
+| Start All Stopped Containers | Start every stopped container in parallel |
+| Stop All Running Containers | Stop every running container in parallel |
+| Remove All Stopped Containers | Remove every stopped container in parallel |
+| Toggle BC Filter | Switch between showing all containers and images, or only BC ones |
 
-### Connection & Networking
+### Connection and Networking
 
 | Command | Description |
 |---------|-------------|
-| Open Web Client | Open Business Central in your browser |
-| Open Container Terminal | PowerShell session inside the container |
-| View Container Logs | Stream logs in real time |
-| Copy Container IP | Copy the container's IP address |
-| Setup Networking | Update hosts file + install SSL certificate |
-| Update Hosts File | Map container hostname to its IP |
-| Install SSL Certificate | Trust the container's self-signed certificate |
+| Open Web Client | Open the BC web client in your browser. Configures networking automatically if needed. |
+| Open Container Terminal | Open a PowerShell session inside the container |
+| View Container Logs | Stream container logs in a terminal |
+| Copy Container IP | Copy the container's current IP address |
+| Setup Networking | Update the hosts file and install the SSL certificate |
+| Update Hosts File | Map the container hostname to its current IP |
+| Install SSL Certificate | Add the container's certificate to Windows Trusted Root |
 
 ### AL Development
 
 | Command | Description |
 |---------|-------------|
-| Generate AL Launch Configuration | Write `.vscode/launch.json` |
-| Preview launch.json in New Tab | Open config for review |
-| Copy launch.json to Clipboard | Copy config JSON |
-| Compile AL App in Container | Compile using `alc.exe` inside the container |
-| Publish AL App to Container | Publish > Sync > Install a `.app` file |
+| Generate AL Launch Configuration | Write `.vscode/launch.json` to the current workspace |
+| Preview launch.json in New Tab | Open the generated config for review |
+| Copy launch.json to Clipboard | Copy the generated config to your clipboard |
+| Compile AL App in Container | Compile your AL project using `alc.exe` inside the container |
+| Publish AL App to Container | Publish, sync, and install a `.app` file |
 
 ### BC Operations
 
 | Command | Description |
 |---------|-------------|
-| Upload License File | Import a `.flf` or `.bclicense` file |
-| Add BC User | Create a user with custom permissions |
-| Add Test Users | Create 3 standard test users |
-| Backup Database | Create a compressed `.bak` backup |
+| Upload License File | Import a `.flf` or `.bclicense` file into the container |
+| Add BC User | Create a user with a custom name, password, and permission set |
+| Add Test Users | Create three standard test users |
+| Backup Database | Create a `.bak` backup via SQL Server |
 | Restore Database | Restore from a `.bak` file |
-| Install Test Toolkit | Install test framework or full test toolkit |
-| Edit NST Settings | View/edit NavServerTier configuration |
-| View Event Log | Retrieve recent event log entries |
-| Show Container Stats | Live resource monitoring |
+| Install Test Toolkit | Install the BC test framework or full test toolkit |
+| Edit NST Settings | View and edit NavServerTier configuration |
+| View Event Log | Retrieve recent Windows Event Log entries from inside the container |
+| Show Container Stats | Open the live resource monitoring panel |
 
 ### Container Profiles
 
 | Command | Description |
 |---------|-------------|
-| Save Container Profile | Save container configuration |
-| Load Container Profile | Create container from saved profile |
-| Edit Container Profile | Update an existing saved profile |
+| Save Container Profile | Save current configuration settings to a named profile |
+| Load Container Profile | Apply a saved profile to your VS Code settings |
+| Edit Container Profile | Update a saved profile with fields pre-filled |
 | Delete Container Profile | Remove a saved profile |
 
 ### Container Annotations
@@ -437,74 +591,237 @@ All commands are available from the Command Palette (`Ctrl+Shift+P`) under the *
 | Command | Description |
 |---------|-------------|
 | Create Volume | Create a new Docker volume |
-| Remove Volume | Delete a Docker volume |
 | Inspect Volume | View volume details |
+| Remove Volume | Delete a Docker volume |
 
 ### Images
 
 | Command | Description |
 |---------|-------------|
+| Pre-Pull BC Image | Download the base BC image in the background |
 | Remove Image | Delete a local Docker image |
-| Pre-Pull BC Image | Download the base BC image ahead of time |
 
 </details>
 
 ---
 
-## Extension Settings
+## Troubleshooting
 
-Configure defaults under **Settings > Extensions > BC Docker Manager**:
+### VS Code reports a command was not found
 
-| Setting | Default | Description |
-|---------|---------|-------------|
-| `bcDockerManager.defaultMemory` | `8G` | Memory limit for new containers (e.g. `4G`, `8G`, `16G`) |
-| `bcDockerManager.defaultIsolation` | `hyperv` | Isolation mode: `hyperv` or `process` |
-| `bcDockerManager.defaultAuth` | `UserPassword` | Authentication: `UserPassword`, `NavUserPassword`, or `Windows` |
-| `bcDockerManager.defaultCountry` | `us` | Default country for artifact browsing (e.g. `us`, `w1`, `de`, `fr`) |
-| `bcDockerManager.defaultDns` | `8.8.8.8` | DNS server for containers |
-| `bcDockerManager.defaultArtifactType` | `sandbox` | Default artifact tab: `sandbox` or `onprem` |
-| `bcDockerManager.showReleaseNotesOnUpdate` | `true` | Show the release notes panel automatically when a new version is installed |
+**Symptom:** A notification appears saying `command 'bcDockerManager.X' not found`.
 
----
+**Cause:** The extension did not activate correctly, or it crashed during startup.
 
-## Known Issues
-
-- **Container IPs change on restart** - use **Update Hosts File** (or **Setup Networking**) after restarting a container.
-- **Docker Engine installation requires a reboot** to enable Windows Containers for the first time.
-- **Docker Desktop conflict** - if Docker Desktop is installed, the standalone Docker Engine may conflict. The extension warns you if this is detected.
+**Steps:**
+1. Open the Output panel (`View > Output`) and select **BC Docker Manager** from the dropdown.
+2. Look for any error message near the top of the log.
+3. Reload VS Code (`Ctrl+Shift+P` > **Developer: Reload Window**).
+4. If the error returns, confirm that VS Code is running as Administrator.
+5. If the problem persists, open **Extensions** in the sidebar, find **BC Docker Manager**, click **Disable**, then **Enable**.
 
 ---
 
-## Release Notes
+### The container list is empty after creating a container
 
-### 1.0.0
+**Symptom:** You started container creation but the new container does not appear in the sidebar.
 
-Initial release:
-- BC Artifacts Explorer with CDN browsing
-- Native container creation via `docker run`
-- Container lifecycle management (start, stop, restart, remove)
-- AL launch.json generation, preview, and clipboard copy
-- Environment setup wizard (Hyper-V, Windows Containers, Docker Engine)
-- Hosts file and SSL certificate management
-- User management and test user creation
-- Database backup and restore
-- Container profiles (save/load)
-- Bulk operations (start all, stop all, remove all)
-- Live container stats monitoring
-- Volume management
-- Container export/import
-- AL app compilation and publishing
-- Test toolkit installation
-- NST settings editor
-- Event log viewer
+**Cause:** The BC filter may be active. New containers do not carry BC labels until BC initialization finishes.
+
+**Steps:**
+1. Click **Toggle BC Filter** in the Containers panel toolbar to show all containers.
+2. If the container appears with the filter off, wait for BC to finish initializing. The container will appear in the filtered view once BC is ready.
+3. If the container does not appear at all, check the output channel for error messages.
+
+---
+
+### Container creation fails or exits before BC is ready
+
+**Symptom:** The progress notification disappears or shows an error before BC reports as ready.
+
+| Cause | Resolution |
+|-------|-----------|
+| Not enough memory | Increase `bcDockerManager.defaultMemory` to `8G` or higher. BC requires at least 4 GB. |
+| Missing or invalid license | Upload a valid `.flf` or `.bclicense` file using **Upload License File** after the container starts. |
+| Incompatible artifact | Try a different BC version. Some older artifacts may not be compatible with the current base image. |
+| Docker daemon not running | Open the **Environment** panel and click **Start Docker Engine**. |
+| Not enough disk space | BC images are 10-20 GB. Ensure you have at least 30 GB free before creating a container. |
+
+The output channel always shows the last 50 log lines when a container exits unexpectedly. Check there first.
+
+---
+
+### The BC web client shows a certificate error
+
+**Symptom:** The browser shows "Your connection is not private" or a similar certificate warning.
+
+**Cause:** The SSL certificate for the container has not been installed in Windows Trusted Root, or the hosts file entry is stale.
+
+**Steps:**
+1. Right-click the container and choose **Setup Networking**. This updates the hosts file and installs the certificate in one step.
+2. Close and reopen the browser tab.
+3. If the error still appears after restarting the container, the IP may have changed. Run **Setup Networking** again.
+
+---
+
+### Networking setup fails with "Cannot determine IP"
+
+**Symptom:** Setup Networking reports that it cannot find the container's IP address.
+
+**Cause:** The container may be stopped, or Docker has not yet assigned an IP.
+
+**Steps:**
+1. Check that the container is running (green icon in the sidebar).
+2. Wait 10-15 seconds after the container starts, then try again.
+3. Run **Copy Container IP** to verify whether the extension can read the IP. An empty result confirms that Docker has not assigned an address yet.
+
+---
+
+### File transfers are slow or produce errors
+
+**Symptom:** Backup, restore, or license upload hangs, produces errors, or is unexpectedly slow.
+
+**Steps:**
+1. Confirm you are running version 1.4.0 or later. The streaming file transfer was introduced in that version. Earlier versions spawned one process per chunk, which was very slow on large files.
+2. Open the Output panel and check for error messages.
+3. Ensure the container has enough disk space for the operation.
+4. During a restore, the BC service tier is stopped. Do not interact with the container while a restore is in progress.
+
+---
+
+### Docker Desktop conflict
+
+**Symptom:** Docker commands fail or produce unexpected results after installing Docker Desktop alongside the standalone Docker Engine.
+
+**Cause:** Docker Desktop installs its own `docker.exe` and a named context that may override the standalone engine.
+
+**Steps:**
+1. The extension shows a warning if Docker Desktop is detected alongside the standalone engine.
+2. Use either Docker Desktop or the standalone engine, not both at the same time.
+3. To use the standalone engine, either uninstall Docker Desktop or switch contexts: `docker context use default`.
+
+---
+
+### Container IP changes after restart
+
+**Cause:** Docker assigns new IP addresses on each container start. The hosts file entry from the previous start becomes stale.
+
+**Resolution:** After restarting a container, right-click it and choose **Setup Networking** to update the hosts file and reinstall the certificate for the new IP.
+
+---
+
+## Security and Permissions
+
+BC Docker Manager requires VS Code to run as **Administrator** for the following operations:
+
+| Operation | Why elevation is needed |
+|-----------|------------------------|
+| Update Hosts File | `C:\Windows\System32\drivers\etc\hosts` is owned by SYSTEM. Writing to it requires Administrator access. |
+| Install SSL Certificate | Adding a certificate to the Windows Trusted Root store requires Administrator access to the system certificate store. |
+| Enable Hyper-V and Windows Containers | `Enable-WindowsOptionalFeature` modifies Windows components and requires Administrator access. |
+| Install Docker Engine | Writing to `C:\Program Files` and registering a Windows service requires Administrator access. |
+| Start Docker Engine | Starting a Windows service requires Administrator access. |
+
+**Operations that do not require elevation:**
+- Browsing BC artifacts from the CDN
+- Reading container, image, and volume lists
+- Viewing logs, stats, and event log entries
+- Generating `launch.json`
+- Managing profiles and annotations
+- AL app compilation and publishing (runs inside the container)
+
+All Docker CLI calls are made to the local Docker Engine over the named pipe `\\.\pipe\docker_engine`. No data is sent to any external service except the Microsoft BC CDN (for artifact metadata) and the VS Code telemetry endpoint.
+
+---
+
+## What's New
+
+See [CHANGELOG.md](CHANGELOG.md) for the complete release history.
+
+**1.5.1** -- Renamed the "What's New" command to "Show Release Notes" in the Command Palette. Internal architecture improvements: retry with exponential backoff and full jitter on Docker CLI calls, process lifecycle tracking, structured logger with level filtering and automatic telemetry forwarding, centralized configuration service, debounced tree view refresh, and a stale-entry bug fix in the SWR cache.
+
+**1.5.0** -- Container tags and notes. Container exit diagnostics that show the last 50 log lines when a container stops unexpectedly. Uppercase letters blocked at container naming time to prevent DNS and SSL failures. Release notes panel with automatic opening after each update.
+
+**1.4.0** -- Edit Container Profile command with pre-filled fields. Streaming file transfer through a single persistent `docker exec` process with a 48 KB window. SQL Server Express edition detection for backup. ANSI escape code stripping from error messages.
+
+**1.3.0** -- Phase-aware progress during container initialization. Immediate sidebar placeholder before Docker reports the container exists. Cancellation support with automatic container cleanup. Completion notification with quick links to the web client and `launch.json`.
+
+---
+
+## Contributing
+
+Contributions are welcome. The repository is at [github.com/jeffreybulanadi/bc-docker-manager](https://github.com/jeffreybulanadi/bc-docker-manager).
+
+### Building from Source
+
+Requirements: Node.js 20 or later, npm.
+
+```bash
+git clone https://github.com/jeffreybulanadi/bc-docker-manager.git
+cd bc-docker-manager
+npm install
+```
+
+**Type check:**
+```bash
+npx tsc --noEmit
+```
+
+**Run unit tests:**
+```bash
+npx jest --no-coverage
+```
+
+**Run unit tests with coverage:**
+```bash
+npx jest --coverage
+```
+
+**Build the extension bundle:**
+```bash
+node esbuild.js
+```
+
+The extension compiles to `out/extension.js` using esbuild. Tests are colocated with their source files -- for example, `src/docker/dockerService.test.ts` tests `src/docker/dockerService.ts`.
+
+### Project Structure
+
+```
+src/
+  docker/       Docker CLI wrapper and BC container operations
+  registry/     BC Artifacts CDN client
+  services/     Shared services: SWR cache, logger, telemetry, configuration, annotations
+  tree/         VS Code TreeView providers for Containers, Images, Volumes, and Environment
+  util/         Utility functions
+  webview/      Webview panels for the Artifacts Explorer and Release Notes
+  extension.ts  Extension entry point and command registration
+```
+
+### CI
+
+All pull requests run the CI workflow, which type-checks the project and runs all unit tests on Node.js 20 and 22. The CI badge at the top of this file reflects the current status of the `main` branch.
+
+Branch protection requires both `Build and test (20.x)` and `Build and test (22.x)` to pass before a pull request can be merged.
+
+### Reporting Issues
+
+Open an issue at [github.com/jeffreybulanadi/bc-docker-manager/issues](https://github.com/jeffreybulanadi/bc-docker-manager/issues). Include:
+- Your Windows version and build number
+- Your Docker Engine version (`docker version` in a terminal)
+- The relevant output from the **BC Docker Manager** output channel in VS Code
+- Steps to reproduce the problem
 
 ---
 
 ## Telemetry
 
-This extension collects **anonymous** error and usage telemetry using the official [`@vscode/extension-telemetry`](https://www.npmjs.com/package/@vscode/extension-telemetry) package to help improve reliability. **No personal data is collected.** Telemetry respects your VS Code setting - disable it anytime:
+This extension collects **anonymous** error and usage telemetry using the official [`@vscode/extension-telemetry`](https://www.npmjs.com/package/@vscode/extension-telemetry) package. No personal data is collected. Error-level log messages are forwarded to telemetry automatically through the structured logger.
+
+Telemetry respects your VS Code setting:
 
 > **Settings > Telemetry: Telemetry Level > off**
+
+Setting telemetry to `off` in VS Code disables all telemetry collection for this extension.
 
 ---
 
@@ -515,5 +832,5 @@ This extension collects **anonymous** error and usage telemetry using the offici
 ---
 
 <p align="center">
-  <sub>Made with care for the Business Central developer community</sub>
+  <sub>Built for the Business Central developer community</sub>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # BC Docker Manager
 
 [![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/jeffreybulanadi.bc-docker-manager?label=VS%20Code%20Marketplace&logo=visual-studio-code&color=0078d7)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.bc-docker-manager)
-[![Installs](https://img.shields.io/visual-studio-marketplace/i/jeffreybulanadi.bc-docker-manager?color=63ba83)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.bc-docker-manager)
 [![CI](https://github.com/jeffreybulanadi/bc-docker-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/jeffreybulanadi/bc-docker-manager/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-> Manage Business Central Docker containers from inside VS Code. Browse artifacts from the Microsoft CDN, create containers, develop AL apps, and keep your environment healthy -- all without installing BcContainerHelper or Docker Desktop.
+> Manage Business Central Docker containers directly from VS Code. Browse artifacts from the Microsoft CDN, create containers, develop AL apps, and keep your environment healthy -- all from a single sidebar panel.
 
 > **Administrator required.** VS Code must be launched as Administrator. Some operations write to `C:\Windows\System32\drivers\etc\hosts`, install certificates into the Windows Trusted Root store, and interact with Windows optional features. These require elevation.
 
@@ -51,22 +50,16 @@
 
 ## Why BC Docker Manager
 
-Business Central development on Windows typically requires either **BcContainerHelper** (a PowerShell module with many dependencies) or **Docker Desktop** (a paid product for most commercial teams). Both add significant overhead to a developer workstation.
+BC Docker Manager brings the full Business Central Docker workflow into VS Code. Whether you are coming from BcContainerHelper and PowerShell-based automation, or starting fresh with BC development, the extension gives you a guided environment, integrated tooling, and real-time visibility into your containers -- all without leaving the editor.
 
-BC Docker Manager takes a different approach. It calls the Docker Engine directly using the `docker` CLI, without going through BcContainerHelper or Docker Desktop's management layer. You get the same results with fewer moving parts.
+Every action in the sidebar maps to standard `docker` commands. There is no custom daemon, no additional service, and no external module required on the host machine. The extension installs Docker Engine for you if it is not already set up.
 
-**What you avoid:**
-- Installing and maintaining the BcContainerHelper PowerShell module
-- Paying for a Docker Desktop license for commercial use
-- Running Docker Desktop's background services and extra memory overhead
-- Writing PowerShell scripts for every routine container task
-
-**What you get instead:**
+**What it brings to your workflow:**
 - A VS Code sidebar that shows your containers, images, and volumes in real time
 - A CDN browser that lists every published BC artifact -- sandbox and on-premises -- with filtering and sorting
 - Container creation, networking, licensing, AL compilation, database backup, and more, all from the same panel
 - Persistent tags and notes on containers so you always know which container is which
-- Container profiles that save and restore full configurations
+- Container profiles that save and restore full configurations across machines
 
 The extension is tested against Node.js 20 and 22 on every pull request. It has no runtime dependency on PowerShell modules outside the container itself.
 
@@ -220,6 +213,10 @@ Right-click any container to see the full action menu, organized into groups:
 
 Attach tags and notes to any container to keep track of what each one is for. Annotations are stored in VS Code global state and survive container restarts, recreations, and VS Code restarts. They do not depend on Docker labels or container metadata.
 
+<!-- SCREENSHOT: The Containers panel showing a container with both tags and a note visible.
+     Tags should appear inline as "#tag1 #tag2" in the container description row.
+     The right-click context menu should be open, showing "Set Container Tags", "Set Container Note", and "Clear Container Note and Tags".
+     Save as: screenshots/tags/set-notes-and-tags-menu.jpg -->
 ![Container with tags and note set](screenshots/tags/set-notes-and-tags-menu.jpg)
 
 #### Tags
@@ -228,6 +225,8 @@ Right-click any container and choose **Set Container Tags**. Enter a comma-separ
 
 Tags appear inline in the container list as `#client1 #sandbox #v25` so you can identify containers at a glance without hovering.
 
+<!-- SCREENSHOT: The Containers panel with a container showing tags inline in its description row, e.g. "#client1 #sandbox #v25".
+     Save as: screenshots/tags/tags-and-notes-set.jpg -->
 ![Tags shown in container list](screenshots/tags/tags-and-notes-set.jpg)
 
 #### Notes
@@ -236,6 +235,9 @@ Right-click any container and choose **Set Container Note**. Enter any free-text
 
 The note appears at the bottom of the container tooltip when you hover over the container name in the sidebar.
 
+<!-- SCREENSHOT: The VS Code quick input box showing the "Set Container Note" prompt with a text field.
+     Optionally show the container tooltip visible in the background displaying the note.
+     Save as: screenshots/tags/set-notes.jpg -->
 ![Set Container Note menu](screenshots/tags/set-notes.jpg)
 
 #### Clearing Annotations
@@ -296,6 +298,10 @@ The `launch.json` file connects the AL Language extension to a running BC contai
 
 Right-click a running container and choose **Generate AL Launch Configuration**. The file is written to the workspace that is currently open in VS Code. If no workspace is open, you will be asked to select a folder.
 
+<!-- SCREENSHOT: A VS Code workspace with the generated .vscode/launch.json open in the editor,
+     showing the server, port, and container name fields populated.
+     Save as: screenshots/launch-json.png -->
+
 #### Compile AL App
 
 Compile your AL project using `alc.exe` inside the container:
@@ -319,6 +325,10 @@ Deploy a compiled `.app` file directly to a container:
 ### Networking and SSL
 
 BC containers use custom hostnames and self-signed SSL certificates. Browsers reject self-signed certificates by default, and the container hostname does not resolve until it is added to your hosts file. The extension handles both.
+
+<!-- SCREENSHOT: The VS Code notification area showing "Networking setup complete" after running Setup Networking,
+     or the quick pick showing the "Setup Networking", "Update Hosts File", and "Install SSL Certificate" options.
+     Save as: screenshots/networking.png -->
 
 | Command | What it does |
 |---------|-------------|
@@ -357,6 +367,10 @@ Create BC users inside a running container without opening the web client or wri
 
 Backup and restore run through a single persistent streaming connection to the container. There is no temporary file staging on the host; data flows directly through the `docker exec` channel.
 
+<!-- SCREENSHOT: The VS Code output channel showing a backup or restore operation in progress,
+     with log lines showing the streaming progress and completion message.
+     Save as: screenshots/database-backup.png -->
+
 | Command | What it does |
 |---------|-------------|
 | Backup Database | Creates a `.bak` file inside the container using SQL Server's `BACKUP DATABASE` command, then copies it to a path you choose on your machine |
@@ -376,6 +390,9 @@ Backup and restore run through a single persistent streaming connection to the c
 | View Container Logs | Opens a terminal and streams `docker logs --follow` in real time |
 | View Event Log | Retrieves recent Windows Event Log entries from the MicrosoftDynamicsNavServer and MSSQL sources inside the container |
 | Edit NST Settings | Opens the NavServerTier configuration file for the container's BC service tier. You can edit values and optionally restart the service to apply changes. |
+
+<!-- SCREENSHOT: The Show Container Stats webview panel open, showing live CPU, memory, network I/O, and block I/O readings for a running container.
+     Save as: screenshots/container-stats.png -->
 
 **Container exit diagnostics:** If a container stops before BC finishes initializing, the last 50 log lines appear in the output channel immediately. Common causes are listed as a hint: not enough memory, missing license, or incompatible artifact. Networking setup is skipped in this case to avoid misleading error messages.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # BC Docker Manager
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/jeffreybulanadi.bc-docker-manager?label=VS%20Code%20Marketplace&logo=visual-studio-code&color=0078d7)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.bc-docker-manager)
+[![VS Code Marketplace](https://img.shields.io/github/package-json/v/jeffreybulanadi/bc-docker-manager?logo=visual-studio-code&color=0078d7&label=VS%20Code%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=jeffreybulanadi.bc-docker-manager)
 [![CI](https://github.com/jeffreybulanadi/bc-docker-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/jeffreybulanadi/bc-docker-manager/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-> Manage Business Central Docker containers directly from VS Code. Browse artifacts from the Microsoft CDN, create containers, develop AL apps, and keep your environment healthy -- all from a single sidebar panel.
+> Manage Business Central Docker containers directly from VS Code. Browse artifacts from the Microsoft CDN, create containers, develop AL apps, and keep your environment healthy, with everything accessible from a single sidebar panel.
 
 > **Administrator required.** VS Code must be launched as Administrator. Some operations write to `C:\Windows\System32\drivers\etc\hosts`, install certificates into the Windows Trusted Root store, and interact with Windows optional features. These require elevation.
 
@@ -42,6 +42,7 @@
 - [Troubleshooting](#troubleshooting)
 - [Security and Permissions](#security-and-permissions)
 - [What's New](#whats-new)
+- [Guides and Resources](#guides-and-resources)
 - [Contributing](#contributing)
 - [Telemetry](#telemetry)
 - [License](#license)
@@ -50,13 +51,13 @@
 
 ## Why BC Docker Manager
 
-BC Docker Manager brings the full Business Central Docker workflow into VS Code. Whether you are coming from BcContainerHelper and PowerShell-based automation, or starting fresh with BC development, the extension gives you a guided environment, integrated tooling, and real-time visibility into your containers -- all without leaving the editor.
+BC Docker Manager brings the full Business Central Docker workflow into VS Code. Whether you are coming from BcContainerHelper and PowerShell-based automation, or starting fresh with BC development, the extension gives you a guided environment, integrated tooling, and real-time visibility into your containers, without leaving the editor.
 
 Every action in the sidebar maps to standard `docker` commands. There is no custom daemon, no additional service, and no external module required on the host machine. The extension installs Docker Engine for you if it is not already set up.
 
 **What it brings to your workflow:**
 - A VS Code sidebar that shows your containers, images, and volumes in real time
-- A CDN browser that lists every published BC artifact -- sandbox and on-premises -- with filtering and sorting
+- A CDN browser that lists every published BC artifact, sandbox and on-premises, with filtering and sorting
 - Container creation, networking, licensing, AL compilation, database backup, and more, all from the same panel
 - Persistent tags and notes on containers so you always know which container is which
 - Container profiles that save and restore full configurations across machines
@@ -76,7 +77,7 @@ The extension is tested against Node.js 20 and 22 on every pull request. It has 
 | Hyper-V | Any | The extension can enable this for you. Requires a restart. |
 | Docker Engine | Any current release | The extension can install this for you. Docker Desktop is not required. |
 
-> **Windows Home users:** Hyper-V is not available on Windows Home editions. You need Windows 10 or 11 Pro, Enterprise, or Education -- or Windows Server.
+> **Windows Home users:** Hyper-V is not available on Windows Home editions. You need Windows 10 or 11 Pro, Enterprise, or Education. Windows Server editions are also supported.
 
 ### Quick Start
 
@@ -93,10 +94,10 @@ The extension is tested against Node.js 20 and 22 on every pull request. It has 
 
 The container creation wizard collects four inputs:
 
-1. **Container name** -- A short lowercase name, for example `bc25us`. The name becomes the container's DNS hostname and the CN of its SSL certificate. Uppercase letters are blocked. Underscores trigger a warning because they are not valid in DNS hostnames.
-2. **Username** -- The BC administrator account. Default: `admin`.
-3. **Password** -- The BC administrator password. BC enforces password complexity requirements.
-4. **Accept EULA** -- You must agree to the Microsoft Business Central EULA.
+1. **Container name.** A short lowercase name, for example `bc25us`. The name becomes the container's DNS hostname and the CN of its SSL certificate. Uppercase letters are blocked. Underscores trigger a warning because they are not valid in DNS hostnames.
+2. **Username.** The BC administrator account. Default: `admin`.
+3. **Password.** The BC administrator password. BC enforces password complexity requirements.
+4. **Accept EULA.** You must agree to the Microsoft Business Central EULA.
 
 After you confirm, the extension:
 - Runs `docker run` with your chosen isolation mode, memory limit, and authentication settings
@@ -112,13 +113,13 @@ You can cancel at any time using the **Cancel** button in the progress notificat
 
 ## How It Works
 
-BC Docker Manager is a VS Code extension written in TypeScript. It communicates with Docker by running the `docker` CLI directly -- the same commands you would type in a terminal. There is no custom daemon, no additional service, and no PowerShell module required on the host machine.
+BC Docker Manager is a VS Code extension written in TypeScript. It communicates with Docker by running the `docker` CLI directly, the same commands you would type in a terminal. There is no custom daemon, no additional service, and no PowerShell module required on the host machine.
 
 **Artifact browsing** fetches metadata from the Microsoft BC CDN (`bcartifacts.azureedge.net`) and caches it using a stale-while-revalidate (SWR) strategy. The list is shown immediately from cache while fresh data loads in the background. When the background fetch finishes and the data has changed, the view updates automatically. Cache entries expire after 10 seconds with a small random jitter to spread out concurrent requests.
 
 **Container and image data** is also served from the SWR cache. The sidebar renders in under a millisecond from cache, then refreshes silently. The cache invalidates immediately after any create, start, stop, restart, or remove operation.
 
-**File transfers** (license upload, AL app publish, database backup, database restore) use a single persistent `docker exec` process. The extension opens one long-running PowerShell session inside the container and streams data through a 48 KB sliding window, regardless of file size. An earlier design spawned a new process per 5-50 KB chunk. On a 500 MB database backup that was roughly 10,000 process starts at around 400 ms each -- hours instead of seconds.
+**File transfers** (license upload, AL app publish, database backup, database restore) use a single persistent `docker exec` process. The extension opens one long-running PowerShell session inside the container and streams data through a 48 KB sliding window, regardless of file size. An earlier design spawned a new process per 5-50 KB chunk. On a 500 MB database backup, that came to roughly 10,000 process starts at around 400 ms each: hours instead of seconds.
 
 **Docker CLI calls** that may fail transiently (network blips, Docker daemon startup) are retried with exponential backoff and full jitter. The maximum retry window is bounded to prevent a thundering-herd effect when multiple commands are issued at the same time.
 
@@ -138,14 +139,14 @@ Browse every Business Central artifact published to the Microsoft CDN without le
      Save as: screenshots/artifacts-explorer.png -->
 ![Artifacts Explorer](screenshots/artifacts-explorer.png)
 
-- **Two artifact types** -- Switch between Sandbox and OnPrem using the tabs at the top.
-- **Filter by country** -- Select from the full list of country codes (`us`, `w1`, `de`, `dk`, `nl`, `fr`, `gb`, and more).
-- **Filter by major version** -- Narrow down to a specific BC major release.
-- **Free-text search** -- Type any part of a version string or date to filter inline.
-- **Sortable columns** -- Click any column header to sort by version, country, or date.
-- **Infinite scroll** -- More rows load automatically as you scroll down.
-- **One-click actions** -- Copy the version string, copy the full CDN URL, or start container creation.
-- **CDN health check** -- Run **Test BC Artifacts CDN Connection** from the command palette to verify your network can reach the CDN.
+- **Two artifact types:** Switch between Sandbox and OnPrem using the tabs at the top.
+- **Filter by country:** Select from the full list of country codes (`us`, `w1`, `de`, `dk`, `nl`, `fr`, `gb`, and more).
+- **Filter by major version:** Narrow down to a specific BC major release.
+- **Free-text search:** Type any part of a version string or date to filter inline.
+- **Sortable columns:** Click any column header to sort by version, country, or date.
+- **Infinite scroll:** More rows load automatically as you scroll down.
+- **One-click actions:** Copy the version string, copy the full CDN URL, or start container creation.
+- **CDN health check:** Run **Test BC Artifacts CDN Connection** from the command palette to verify your network can reach the CDN.
 
 #### Container Creation Wizard
 
@@ -175,18 +176,18 @@ All your containers are listed in the **Containers** sidebar panel. Running cont
 | Stop | Click the stop button on a running container, or right-click > Stop Container |
 | Restart | Right-click > Restart Container |
 | Remove | Click the trash button, or right-click > Remove Container |
-| Export | Right-click > Export Container -- saves the container as a `.tar` file |
+| Export | Right-click > Export Container: saves the container as a `.tar` file |
 | Import | Use the toolbar menu at the top of the Containers panel to import a `.tar` file |
 
 #### Quick Access
 
 Click the inline icons on any running container:
 
-- **Open Web Client** -- opens `https://<containername>/BC/` in your browser. Networking (hosts file and SSL certificate) is configured automatically before the browser opens if it has not been set up yet.
-- **Open Terminal** -- opens an interactive PowerShell session inside the running container.
-- **View Logs** -- streams `docker logs --follow` in a VS Code terminal, showing new log lines as they arrive.
-- **Copy IP** -- copies the container's current IP address to your clipboard.
-- **Show Stats** -- opens a live statistics view that updates every 5 seconds.
+- **Open Web Client:** Opens `https://<containername>/BC/` in your browser. Networking (hosts file and SSL certificate) is configured automatically before the browser opens if it has not been set up yet.
+- **Open Terminal:** Opens an interactive PowerShell session inside the running container.
+- **View Logs:** Streams `docker logs --follow` in a VS Code terminal, showing new log lines as they arrive.
+- **Copy IP:** Copies the container's current IP address to your clipboard.
+- **Show Stats:** Opens a live statistics view that updates every 5 seconds.
 
 #### Context Menu
 
@@ -274,7 +275,7 @@ The **Environment** panel checks your system before you start and tells you exac
 | Button | What it does |
 |--------|-------------|
 | Setup Everything | Runs all fixes in the correct order in a single step |
-| Enable Hyper-V and Windows Containers | Runs `Enable-WindowsOptionalFeature -FeatureName Hyper-V, Containers` -- requires a restart |
+| Enable Hyper-V and Windows Containers | Runs `Enable-WindowsOptionalFeature -FeatureName Hyper-V, Containers`, which requires a restart |
 | Install Docker Engine | Downloads the standalone Docker Engine from `download.docker.com` and installs it as a Windows service. Docker Desktop is not required. |
 | Start Docker Engine | Starts the `docker` Windows service if it is installed but stopped |
 
@@ -284,7 +285,7 @@ The **Environment** panel checks your system before you start and tells you exac
 
 ### AL Development
 
-BC Docker Manager works alongside the [AL Language extension](https://marketplace.visualstudio.com/items?itemName=ms-dynamics-smb.al) to speed up AL development. You do not need `alc.exe` installed on your host machine -- the extension uses the copy inside the container.
+BC Docker Manager works alongside the [AL Language extension](https://marketplace.visualstudio.com/items?itemName=ms-dynamics-smb.al) to speed up AL development. You do not need `alc.exe` installed on your host machine; the extension uses the copy inside the container.
 
 #### Generate launch.json
 
@@ -755,13 +756,23 @@ All Docker CLI calls are made to the local Docker Engine over the named pipe `\\
 
 See [CHANGELOG.md](CHANGELOG.md) for the complete release history.
 
-**1.5.1** -- Renamed the "What's New" command to "Show Release Notes" in the Command Palette. Internal architecture improvements: retry with exponential backoff and full jitter on Docker CLI calls, process lifecycle tracking, structured logger with level filtering and automatic telemetry forwarding, centralized configuration service, debounced tree view refresh, and a stale-entry bug fix in the SWR cache.
+**1.5.1:** Renamed the "What's New" command to "Show Release Notes" in the Command Palette. Internal architecture improvements: retry with exponential backoff and full jitter on Docker CLI calls, process lifecycle tracking, structured logger with level filtering and automatic telemetry forwarding, centralized configuration service, debounced tree view refresh, and a stale-entry bug fix in the SWR cache.
 
-**1.5.0** -- Container tags and notes. Container exit diagnostics that show the last 50 log lines when a container stops unexpectedly. Uppercase letters blocked at container naming time to prevent DNS and SSL failures. Release notes panel with automatic opening after each update.
+**1.5.0:** Container tags and notes. Container exit diagnostics that show the last 50 log lines when a container stops unexpectedly. Uppercase letters blocked at container naming time to prevent DNS and SSL failures. Release notes panel with automatic opening after each update.
 
-**1.4.0** -- Edit Container Profile command with pre-filled fields. Streaming file transfer through a single persistent `docker exec` process with a 48 KB window. SQL Server Express edition detection for backup. ANSI escape code stripping from error messages.
+**1.4.0:** Edit Container Profile command with pre-filled fields. Streaming file transfer through a single persistent `docker exec` process with a 48 KB window. SQL Server Express edition detection for backup. ANSI escape code stripping from error messages.
 
-**1.3.0** -- Phase-aware progress during container initialization. Immediate sidebar placeholder before Docker reports the container exists. Cancellation support with automatic container cleanup. Completion notification with quick links to the web client and `launch.json`.
+**1.3.0:** Phase-aware progress during container initialization. Immediate sidebar placeholder before Docker reports the container exists. Cancellation support with automatic container cleanup. Completion notification with quick links to the web client and `launch.json`.
+
+---
+
+## Guides and Resources
+
+The following guides provide hands-on walkthroughs and deeper context for working with BC Docker Manager.
+
+### Getting Started with BC Containers: A Practical Guide
+
+[BC Docker Manager: Easy Containers](https://learnbeyondbc.com/blogs/bc-docker-manager-easy-containers) covers the full journey from running PowerShell scripts manually to having a working container environment inside VS Code. It walks through artifact selection, container creation, and the reasoning behind each design decision in the extension. A good starting point if you want to understand not just what the extension does, but why it works the way it does.
 
 ---
 
@@ -799,7 +810,7 @@ npx jest --coverage
 node esbuild.js
 ```
 
-The extension compiles to `out/extension.js` using esbuild. Tests are colocated with their source files -- for example, `src/docker/dockerService.test.ts` tests `src/docker/dockerService.ts`.
+The extension compiles to `out/extension.js` using esbuild. Tests are colocated with their source files; for example, `src/docker/dockerService.test.ts` tests `src/docker/dockerService.ts`.
 
 ### Project Structure
 

--- a/src/webview/releaseNotesPanel.ts
+++ b/src/webview/releaseNotesPanel.ts
@@ -49,12 +49,12 @@ pre code {
 `;
 
 const PAGE_CSS = `
-/* ── three-column layout ── */
+/* ── two-column layout ── */
 .rn-layout { display: flex; min-height: 100vh; }
 
 /* ── column 1: version list ── */
 .rn-versions {
-  width: 170px; flex-shrink: 0;
+  width: 175px; flex-shrink: 0;
   padding: 28px 0 40px 14px;
   box-sizing: border-box;
   border-right: 1px solid var(--vscode-panel-border, rgba(128,128,128,.12));
@@ -87,42 +87,11 @@ const PAGE_CSS = `
 .rn-ver-btn.rn-ver-active .rn-ver-num { color: var(--vscode-textLink-foreground); }
 .rn-ver-btn.rn-ver-active .rn-ver-date { color: var(--vscode-foreground); opacity: .6; }
 
-/* ── column 2: in this update ── */
-.rn-itu {
-  width: 155px; flex-shrink: 0;
-  padding: 28px 12px 40px 18px;
-  box-sizing: border-box;
-  border-right: 1px solid var(--vscode-panel-border, rgba(128,128,128,.12));
-}
-.rn-itu-inner { position: sticky; top: 28px; }
-.rn-itu-label {
-  display: block;
-  font-size: .7em; font-weight: 700; letter-spacing: .1em;
-  text-transform: uppercase; opacity: .4;
-  margin: 0 0 8px;
-}
-.rn-itu-list { margin: 0; padding: 0; list-style: none; }
-.rn-itu-list li { margin: 2px 0; }
-.rn-itu-list a {
-  display: block; padding: 3px 0 3px 10px;
-  font-size: .86em; text-decoration: none;
-  color: var(--vscode-foreground); opacity: .6;
-  border-left: 2px solid transparent;
-  transition: opacity .15s, color .15s, border-color .15s;
-  line-height: 1.4;
-}
-.rn-itu-list a:hover { opacity: 1; text-decoration: none; }
-.rn-itu-list a[aria-current="true"] {
-  opacity: 1;
-  color: var(--vscode-textLink-foreground);
-  border-left-color: var(--vscode-textLink-foreground);
-}
-
-/* ── column 3: main content ── */
+/* ── column 2: content (header + in-this-update block + sections) ── */
 .rn-main {
   flex: 1; min-width: 0;
   padding: 28px 48px 60px 36px;
-  max-width: 840px;
+  max-width: 880px;
   box-sizing: border-box;
 }
 
@@ -163,6 +132,29 @@ const PAGE_CSS = `
 /* ── social links ── */
 .rn-social { font-size: .82em; opacity: .55; }
 .rn-social a { opacity: 1; }
+
+/* ── in this update block (inline at top of content) ── */
+.rn-itu-block {
+  margin: 0 0 28px;
+  padding: 14px 18px;
+  border: 1px solid var(--vscode-panel-border, rgba(128,128,128,.15));
+  border-radius: 4px;
+  background: var(--vscode-editor-inactiveSelectionBackground, rgba(128,128,128,.04));
+}
+.rn-itu-label {
+  display: block;
+  font-size: .7em; font-weight: 700; letter-spacing: .1em;
+  text-transform: uppercase; opacity: .45;
+  margin: 0 0 10px;
+}
+.rn-itu-links { display: flex; flex-wrap: wrap; gap: 4px 20px; margin: 0; padding: 0; list-style: none; }
+.rn-itu-links a {
+  font-size: .88em; text-decoration: none;
+  color: var(--vscode-textLink-foreground);
+  opacity: .75; transition: opacity .15s;
+}
+.rn-itu-links a:hover { opacity: 1; text-decoration: underline; }
+.rn-itu-links a[aria-current="true"] { opacity: 1; font-weight: 600; }
 
 /* ── section headings ── */
 .rn-section-wrap { display: flex; align-items: center; margin: 2em 0 .75em; }
@@ -217,12 +209,9 @@ a.rn-contributor:hover {
 .rn-figure figcaption { font-size: .8em; opacity: .55; margin-top: 6px; }
 
 /* ── responsive ── */
-@media (max-width: 660px) {
-  .rn-itu { display: none; }
-  .rn-main { padding: 20px 24px 40px; }
-}
-@media (max-width: 420px) {
+@media (max-width: 460px) {
   .rn-versions { display: none; }
+  .rn-main { padding: 20px 20px 40px; }
 }
 `;
 
@@ -408,12 +397,10 @@ function buildHtml(
   let body: string;
   if (releases.length) {
     const verList = renderVersionList(releases);
-    const ituNav  = renderItuNav(releases);
     const panels  = releases
       .map((r, i) => renderVersionPanel(r, i, i === 0 ? checked : null, toUri))
       .join("");
     body = `<aside class="rn-versions"><div class="rn-versions-inner">${verList}</div></aside>` +
-           `<nav class="rn-itu"><div class="rn-itu-inner">${ituNav}</div></nav>` +
            `<main class="rn-main">${panels}</main>`;
   } else {
     body = `<main class="rn-main"><p>No release notes available.</p></main>`;
@@ -442,15 +429,14 @@ ${body}
   }
   var verBtns  = document.querySelectorAll(".rn-ver-btn");
   var panels   = document.querySelectorAll(".rn-version-panel");
-  var ituLists = document.querySelectorAll(".rn-itu-list");
   var currentIO = null;
 
   function setupScrollSpy(idx) {
     if (currentIO) { currentIO.disconnect(); currentIO = null; }
     if (!("IntersectionObserver" in window)) { return; }
-    var activeList = document.querySelector(".rn-itu-list[data-itu='" + idx + "']");
-    if (!activeList) { return; }
-    var tocLinks = activeList.querySelectorAll("a[data-target]");
+    var activePanel = document.querySelector(".rn-version-panel[data-panel='" + idx + "']");
+    if (!activePanel) { return; }
+    var tocLinks = activePanel.querySelectorAll(".rn-itu-links a[data-target]");
     if (!tocLinks.length) { return; }
     var map = Object.create(null);
     tocLinks.forEach(function(l){ map[l.getAttribute("data-target")] = l; });
@@ -473,7 +459,6 @@ ${body}
       b.classList.toggle("rn-ver-active", +b.getAttribute("data-idx") === idx);
     });
     panels.forEach(function(p){ p.hidden = +p.getAttribute("data-panel") !== idx; });
-    ituLists.forEach(function(ul){ ul.hidden = +ul.getAttribute("data-itu") !== idx; });
     setupScrollSpy(idx);
   }
 
@@ -498,20 +483,7 @@ function renderVersionList(releases: Release[]): string {
   return `<span class="rn-versions-label">Releases</span><ul class="rn-ver-list">${items}</ul>`;
 }
 
-// ── in this update nav (column 2) ────────────────────────────────────────────
-
-function renderItuNav(releases: Release[]): string {
-  const lists = releases.map((r, i) => {
-    const hiddenAttr = i === 0 ? "" : " hidden";
-    const items = r.sections
-      .map(s => `<li><a href="#${vslug(i, s.name)}" data-target="${vslug(i, s.name)}">${esc(s.name)}</a></li>`)
-      .join("");
-    return `<ul class="rn-itu-list" data-itu="${i}"${hiddenAttr}>${items}</ul>`;
-  }).join("");
-  return `<span class="rn-itu-label">In this update</span>${lists}`;
-}
-
-// ── version content panels (column 3) ────────────────────────────────────────
+// ── in this update block (inline at top of each version panel) ───────────────
 
 const SOCIAL_LINKS =
   '<a href="https://www.linkedin.com/in/jeffreybulanadi/">LinkedIn</a>' +
@@ -532,11 +504,19 @@ function renderVersionPanel(
       `<label class="rn-setting"><input type="checkbox" id="chk"${checked}> Show release notes after an update</label>` +
       `<p class="rn-social">Follow on ${SOCIAL_LINKS}</p>`
     : `<p class="rn-date">Released ${esc(r.fmtDate)}</p>`;
-  const header   = `<div class="rn-header"><h1>BC Docker Manager ${esc(r.version)}</h1>${extra}<hr></div>`;
+  const header = `<div class="rn-header"><h1>BC Docker Manager ${esc(r.version)}</h1>${extra}<hr></div>`;
+
+  const ituItems = r.sections
+    .map(s => `<li><a href="#${vslug(idx, s.name)}" data-target="${vslug(idx, s.name)}">${esc(s.name)}</a></li>`)
+    .join("");
+  const ituBlock = r.sections.length
+    ? `<div class="rn-itu-block"><span class="rn-itu-label">In this update</span><ul class="rn-itu-links">${ituItems}</ul></div>`
+    : "";
+
   const sections = r.sections
     .map(s => `<section id="${vslug(idx, s.name)}">${renderSectionHeading(s.name)}${renderSectionContent(s, toUri)}</section>`)
     .join("");
-  return `<div class="rn-version-panel" data-panel="${idx}"${hiddenAttr}>${header}${sections}</div>`;
+  return `<div class="rn-version-panel" data-panel="${idx}"${hiddenAttr}>${header}${ituBlock}${sections}</div>`;
 }
 
 // ── section rendering ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Simplifies the release notes panel from three columns to two.

The version list sidebar remains on the left. The content area on the right now includes an inline 'In this update' navigation block at the top of each version panel, directly above the sections. This matches how VS Code presents its own release notes - the navigation and content share the same column with a clear visual separator.

Changes:
- Removed the middle column and renderItuNav function
- Added inline .rn-itu-block inside each version panel
- Scroll spy now targets .rn-itu-links a[data-target] within the active panel
- activateVersion simplified: no longer manages a separate ITU list element
- All 423 tests pass, type check clean