### PR TITLE
Fix NAV management module bootstrap for BC 28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.5.3] - 2026-05-10
+
+### Fixed
+
+- License upload now works correctly across all supported container images. Certain container images load their administration tools differently from what the extension expected, which caused the upload to fail with a cryptic error or no message at all. The extension now uses a loading approach that works regardless of how the container image is structured internally.
+
+- When you try to upload a license to a container that is not running, the error now clearly says "Container is not running. Start it and try again." instead of showing a raw exit code or an empty failure.
+
+- Error messages from failed commands now include the full output from the operation, not just the error stream. Some container operations write important diagnostic information to the standard output rather than the error output. Both are now captured and shown in the output channel so you can see what actually happened.
+
+---
+
 ## [1.5.2] - 2026-05-06
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bc-docker-manager",
   "displayName": "BC Docker Manager",
   "description": "Manage Business Central Docker containers from VS Code - browse artifacts, create containers, develop AL apps, and configure your environment without BcContainerHelper or Docker Desktop.",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "icon": "resources/icon.png",
   "publisher": "jeffreybulanadi",
   "author": {

--- a/src/docker/bcContainerService.test.ts
+++ b/src/docker/bcContainerService.test.ts
@@ -349,22 +349,25 @@ describe("getContainerInfo", () => {
   });
 
   it("fetches and returns parsed info on first call", async () => {
+    fakeSpawnOk("true"); // docker inspect: container running
     fakeSpawnOk(infoJson);
     const result = await (svc as any).getContainerInfo("mybc");
     expect(result).toEqual({ serverInstance: "NAV", dbName: "MyDB" });
-    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
   });
 
   it("returns cached result on second call within TTL", async () => {
+    fakeSpawnOk("true"); // docker inspect: container running
     fakeSpawnOk(infoJson);
     await (svc as any).getContainerInfo("mybc");
     const result = await (svc as any).getContainerInfo("mybc");
     expect(result).toEqual({ serverInstance: "NAV", dbName: "MyDB" });
-    // spawn should only be called once - second call uses cache
-    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    // inspect + data on first call; second call hits cache
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
   });
 
   it("re-fetches after TTL expires", async () => {
+    fakeSpawnOk("true"); // docker inspect for first fetch
     fakeSpawnOk(infoJson);
     await (svc as any).getContainerInfo("mybc");
 
@@ -377,10 +380,11 @@ describe("getContainerInfo", () => {
       ServerInstance: "BC2",
       DatabaseName: "CronusNew",
     });
+    fakeSpawnOk("true"); // docker inspect for re-fetch
     fakeSpawnOk(updatedJson);
     const result = await (svc as any).getContainerInfo("mybc");
     expect(result).toEqual({ serverInstance: "BC2", dbName: "CronusNew" });
-    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(mockSpawn).toHaveBeenCalledTimes(4);
   });
 
   it("returns defaults on error", async () => {
@@ -390,19 +394,22 @@ describe("getContainerInfo", () => {
   });
 
   it("returns defaults when JSON is invalid", async () => {
+    fakeSpawnOk("true"); // docker inspect: container running
     fakeSpawnOk("not valid json");
     const result = await (svc as any).getContainerInfo("badjson");
     expect(result).toEqual({ serverInstance: "BC", dbName: "CRONUS" });
   });
 
   it("caches separate entries per container", async () => {
+    fakeSpawnOk("true"); // docker inspect for c1
     fakeSpawnOk(JSON.stringify({ ServerInstance: "S1", DatabaseName: "D1" }));
+    fakeSpawnOk("true"); // docker inspect for c2
     fakeSpawnOk(JSON.stringify({ ServerInstance: "S2", DatabaseName: "D2" }));
     const r1 = await (svc as any).getContainerInfo("c1");
     const r2 = await (svc as any).getContainerInfo("c2");
     expect(r1.serverInstance).toBe("S1");
     expect(r2.serverInstance).toBe("S2");
-    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(mockSpawn).toHaveBeenCalledTimes(4);
   });
 });
 
@@ -410,12 +417,14 @@ describe("getContainerInfo", () => {
 
 describe("getServerInstance / getDatabaseName", () => {
   it("getServerInstance delegates to getContainerInfo", async () => {
+    fakeSpawnOk("true"); // docker inspect: container running
     fakeSpawnOk(JSON.stringify({ ServerInstance: "NAV", DatabaseName: "DB1" }));
     const si = await (svc as any).getServerInstance("mybc");
     expect(si).toBe("NAV");
   });
 
   it("getDatabaseName delegates to getContainerInfo", async () => {
+    fakeSpawnOk("true"); // docker inspect: container running
     fakeSpawnOk(JSON.stringify({ ServerInstance: "NAV", DatabaseName: "DB1" }));
     const db = await (svc as any).getDatabaseName("mybc");
     expect(db).toBe("DB1");

--- a/src/docker/bcContainerService.ts
+++ b/src/docker/bcContainerService.ts
@@ -26,13 +26,22 @@ const FILE_TRANSFER_CHUNK = 49_152;
 const FILE_TRANSFER_TIMEOUT_MS = 1_800_000;
 
 /**
- * Import the NAV/BC management module inside the container.
- * Required because we use `-NoProfile` to avoid slow profile loading
- * and unpredictable stdout. Covers both legacy NAV and modern BC paths.
+ * Bootstrap the NAV/BC management module inside the container.
+ *
+ * Sources ServiceSettings.ps1 first so $ServerInstance and $serviceTierFolder
+ * are available, then imports the pure-PowerShell .psm1 directly. This avoids
+ * the NavAdminTool.ps1 stub which in BC 29 dot-sources Admin\NavAdminTool.ps1
+ * with an inherited $PSScriptRoot, causing the .NET 10 management DLL to load
+ * and crash the host pwsh process (exit 255, zero output).
+ *
+ * Always paired with Windows PowerShell 5.x (powershell). PS7 is intentionally
+ * avoided: BC 29 insider builds target .NET 10 and abort pwsh on module load.
  */
 const NAV_MODULE_IMPORT =
-  "$navModule = Get-ChildItem 'C:\\Program Files\\Microsoft Dynamics*\\*\\Service\\NavAdminTool.ps1' -ErrorAction SilentlyContinue | Select-Object -First 1; " +
-  "if ($navModule) { Import-Module $navModule.FullName -DisableNameChecking -ErrorAction SilentlyContinue }; ";
+  ". 'C:\\Run\\ServiceSettings.ps1' *>&1 | Out-Null; " +
+  "$_psm1 = (Get-ChildItem 'C:\\Program Files\\Microsoft Dynamics*\\*\\Service\\Microsoft.Dynamics.Nav.Management.psm1' " +
+  "-ErrorAction SilentlyContinue | Select-Object -First 1).FullName; " +
+  "if ($_psm1) { Import-Module $_psm1 -DisableNameChecking -ErrorAction SilentlyContinue }; ";
 
 // ────────────────────────── Service ────────────────────────────
 
@@ -97,30 +106,78 @@ export class BcContainerService {
     psCommand: string,
     timeoutMs = EXEC_TIMEOUT_MS,
   ): Promise<string> {
-    return withRetry(
-      () => this._processManager.exec(
-        "docker",
-        ["exec", containerName, "powershell", "-NoProfile", "-Command", psCommand],
-        { timeoutMs, maxBufferBytes: 10 * 1024 * 1024 },
-      ),
-      { maxAttempts: 2, retryable: isTransientDockerError },
-    );
+    try {
+      return await withRetry(
+        () => this._processManager.exec(
+          "docker",
+          ["exec", containerName, "powershell", "-NoProfile", "-Command", psCommand],
+          { timeoutMs, maxBufferBytes: 10 * 1024 * 1024 },
+        ),
+        { maxAttempts: 2, retryable: isTransientDockerError },
+      );
+    } catch (err) {
+      throw BcContainerService.wrapExecError(err, containerName);
+    }
   }
 
-  /** Run a NAV/BC PowerShell cmdlet inside a container (imports NavAdminTool). */
+  /**
+   * Run a NAV/BC PowerShell cmdlet inside a container (imports management module).
+   *
+   * Always uses Windows PowerShell 5.x (powershell). pwsh / PS7 is intentionally
+   * avoided: BC 29 ships a management DLL targeting .NET 10 that aborts the pwsh
+   * process with exit 255 before producing any output. PS5 loads the pure-PowerShell
+   * .psm1 path instead, which works across all BC versions.
+   */
   private async execNavInContainer(
     containerName: string,
     psCommand: string,
     timeoutMs = EXEC_TIMEOUT_MS,
   ): Promise<string> {
-    return withRetry(
-      () => this._processManager.exec(
-        "docker",
-        ["exec", containerName, "powershell", "-NoProfile", "-Command", NAV_MODULE_IMPORT + psCommand],
-        { timeoutMs, maxBufferBytes: 10 * 1024 * 1024 },
-      ),
-      { maxAttempts: 2, retryable: isTransientDockerError },
-    );
+    await this._assertContainerRunning(containerName);
+    try {
+      return await withRetry(
+        () => this._processManager.exec(
+          "docker",
+          ["exec", containerName, "powershell", "-NoProfile", "-Command", NAV_MODULE_IMPORT + psCommand],
+          { timeoutMs, maxBufferBytes: 10 * 1024 * 1024 },
+        ),
+        { maxAttempts: 2, retryable: isTransientDockerError },
+      );
+    } catch (err) {
+      throw BcContainerService.wrapExecError(err, containerName);
+    }
+  }
+
+  /**
+   * Translate a raw process error into a user-readable message.
+   *
+   * Only "no such container" is a Docker-daemon-specific phrase that
+   * unambiguously indicates a missing container. Container running-state is
+   * verified via `docker inspect` in _assertContainerRunning before exec
+   * is attempted.
+   */
+  private static wrapExecError(err: unknown, containerName: string): Error {
+    if (!(err instanceof Error)) { return new Error(String(err)); }
+    const msg = err.message;
+    if (/no such container/i.test(msg)) {
+      return new Error(`Container "${containerName}" does not exist. Create it first.`);
+    }
+    return new Error(BcContainerService.cleanPsError(msg) || msg);
+  }
+
+  /**
+   * Probe the container to verify it is in the running state before attempting
+   * a NAV admin exec. Uses `docker inspect` so Hyper-V containers with transient
+   * exit-255 on first exec still get a clear "not running" message.
+   */
+  private async _assertContainerRunning(containerName: string): Promise<void> {
+    const state = await this._run(
+      ["inspect", "--format", "{{.State.Running}}", containerName],
+      5_000,
+    ).catch(() => "false");
+    if (state.trim() !== "true") {
+      throw new Error(`Container "${containerName}" is not running. Start it and try again.`);
+    }
   }
 
   /** Escape single quotes in a path for use inside a PowerShell single-quoted string. */

--- a/src/util/processManager.ts
+++ b/src/util/processManager.ts
@@ -85,8 +85,14 @@ export class ProcessManager {
         if (code === 0) {
           resolve(Buffer.concat(stdoutChunks).toString("utf8"));
         } else {
+          const stdout = Buffer.concat(stdoutChunks).toString("utf8").trim();
+          // Docker on Windows and PowerShell both write diagnostic detail to
+          // stdout in some failure modes. Include both streams so callers always
+          // have actionable context. Exit code is always appended so callers
+          // can pattern-match on it (e.g. 255 = container not running).
           const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
-          reject(new Error(stderr || `Process "${command}" exited with code ${code}`));
+          const body = [stderr, stdout].filter(Boolean).join("\n");
+          reject(new Error(body ? `${body} (exit ${code})` : `Process "${command}" exited with code ${code}`));
         }
       });
 


### PR DESCRIPTION
Fixes license upload failures across BC 25 through containers.

**Root cause:** NavAdminTool.ps1 in BC latest build is a stub that dot-sources Admin\NavAdminTool.ps1. When dot-sourced from an outer script, PowerShell inherits the caller's \\\. The inner Admin script then locates the real \Admin\Microsoft.BusinessCentral.Management.psd1\, which loads a .NET 10 DLL and aborts the host process (exit 255, zero output).

**Fix:** Source \ServiceSettings.ps1\ first (sets \\\ and \\\), then import \Microsoft.Dynamics.Nav.Management.psm1\ directly. That .psm1 is pure PowerShell with no .NET 10 dependency and works consistently across BC 25-latest.

**Also included:**
- \_assertContainerRunning\: probes container state via \docker inspect\ before exec so Hyper-V containers with transient exit-255 get a clear 'not running' message instead of a cryptic error
- \wrapExecError\: translates raw process errors into user-readable messages
- \processManager.ts\: includes stdout alongside stderr in non-zero exit errors, capturing diagnostic output that Docker and PowerShell write to stdout in some failure modes