### PR TITLE
Add tsconfig.test.json so VS Code resolves Jest globals in test files

### DIFF
--- a/src/docker/dockerService.test.ts
+++ b/src/docker/dockerService.test.ts
@@ -789,6 +789,9 @@ describe("DockerService.parseInitPhase", () => {
   });
 });
 
+// ─── buildRunArgs (private, accessed via `any`) ───────────────────
+
+describe("DockerService.buildRunArgs", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const svc = new DockerService() as any;
 

--- a/src/tree/containerProvider.test.ts
+++ b/src/tree/containerProvider.test.ts
@@ -50,7 +50,7 @@ describe("ContainerProvider.getChildren", () => {
 
     expect(children).toHaveLength(1);
     expect(children[0]).toBeInstanceOf(ContainerTreeItem);
-    expect(children[0].container).toEqual(sampleContainer);
+    expect((children[0] as ContainerTreeItem).container).toEqual(sampleContainer);
   });
 
   it("returns empty array when docker returns empty list", async () => {
@@ -202,7 +202,7 @@ describe("ContainerProvider.getChildren - multiple containers", () => {
     expect(children).toHaveLength(3);
     children.forEach((child, i) => {
       expect(child).toBeInstanceOf(ContainerTreeItem);
-      expect(child.container).toEqual(containers[i]);
+      expect((child as ContainerTreeItem).container).toEqual(containers[i]);
     });
   });
 });

--- a/src/tree/volumeProvider.test.ts
+++ b/src/tree/volumeProvider.test.ts
@@ -47,7 +47,7 @@ describe("VolumeTreeItem", () => {
     const item = new VolumeTreeItem(makeVolume());
 
     expect(item.iconPath).toBeDefined();
-    expect(item.iconPath.id).toBe("database");
+    expect((item.iconPath as { id: string }).id).toBe("database");
   });
 
   it("sets description to driver name", () => {
@@ -65,7 +65,7 @@ describe("VolumeTreeItem", () => {
     const item = new VolumeTreeItem(vol);
 
     expect(item.tooltip).toBeDefined();
-    const md = item.tooltip.value as string;
+    const md = (item.tooltip as { value: string }).value;
     expect(md).toContain("**my-vol**");
     expect(md).toContain("local");
     expect(md).toContain("/mnt/data");
@@ -75,7 +75,7 @@ describe("VolumeTreeItem", () => {
     const vol = makeVolume({ mountpoint: "" });
     const item = new VolumeTreeItem(vol);
 
-    const md = item.tooltip.value as string;
+    const md = (item.tooltip as { value: string }).value;
     expect(md).toContain("N/A");
   });
 });

--- a/src/webview/registryPanel.test.ts
+++ b/src/webview/registryPanel.test.ts
@@ -69,7 +69,7 @@ function getPostedMessages(): Record<string, unknown>[] {
   const mock = (vscode.window.createWebviewPanel as jest.Mock);
   const panelMock = mock.mock.results[mock.mock.results.length - 1]?.value;
   return (panelMock?.webview?.postMessage as jest.Mock)?.mock?.calls?.map(
-    (c: unknown[]) => c[0],
+    (c: unknown[]) => c[0] as Record<string, unknown>,
   ) ?? [];
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "types": ["node", "vscode"]
   },
   "include": ["src/**/*"],
   "exclude": [

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.test.ts", "src/vscode-mock.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Test files were excluded from tsconfig.json, leaving the VS Code language server without a project context for them. It fell back to an inferred project that lacked jest type information, causing jest globals to show as unknown when opening test files.

Add tsconfig.test.json covering test files and vscode-mock.ts. Restrict the main tsconfig types to node and vscode only so jest globals no longer bleed into production source.

Also fixed a missing describe wrapper in dockerService.test.ts (the buildRunArgs group had top-level const declarations in module scope), and five pre-existing type narrowing issues in containerProvider, volumeProvider, and registryPanel test files that strict compilation now catches.

All 423 tests pass.